### PR TITLE
Fixed: Typo in material-ui spelling

### DIFF
--- a/content/en/docs/gsoc/_index.md
+++ b/content/en/docs/gsoc/_index.md
@@ -48,7 +48,7 @@ Tech stack
 - Frontend (WebUI)
     -  [React.JS](https://reactjs.org/)
     -  [React Admin](https://marmelab.com/react-admin/)
-    -  [Meterial-UI](https://material-ui.com/)
+    -  [Material-UI](https://material-ui.com/)
 
 
 Recommended steps


### PR DESCRIPTION
Fixed a typo in material-ui spelling, it was meterial-ui.