### PR TITLE
Added reference to package and module definitions in nixpkgs

### DIFF
--- a/content/en/docs/Installation/packages.md
+++ b/content/en/docs/Installation/packages.md
@@ -30,6 +30,7 @@ More packages available, with links to download/install instructions:
 | Arch Linux             | You can install Navidrome via the [`navidrome-bin`](https://aur.archlinux.org/packages/navidrome-bin/) package in the [AUR](https://aur.archlinux.org/). <br/> Alternatively, you can install using the [`navidrome-git`](https://aur.archlinux.org/packages/navidrome-git/) package which will compile Navidrome from source. |
 | Cloudron               | https://www.cloudron.io/store/org.navidrome.cloudronapp.html |
 | Kubernets Chart        | https://artifacthub.io/packages/helm/k8s-at-home/navidrome | 
+| Nix/NixOS              | [Package](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/servers/misc/navidrome/default.nix) and [module](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/services/audio/navidrome.nix) definitions in [nixpkgs](https://github.com/NixOS/nixpkgs) | 
 | OpenMediaVault         | [Instructions using docker-compose](https://forum.openmediavault.org/index.php?thread/36635-how-to-install-navidrome-using-docker-compose-an-airsonic-booksonic-alternative/) |
 | QNAP                   | https://www.qnapclub.eu/en/qpkg/958 |
 | TrueNAS SCALE          | https://truecharts.org/apps/stable/navidrome |


### PR DESCRIPTION
I packaged Navidrome in Nixpkgs some time ago but I never did a PR here  to add a mention to this fact.
If needed, in the future, I could provide a small configuration example to get the service up and running as NixOS module.