### PR TITLE
Include reference to Airsonic API authentication

### DIFF
--- a/content/en/docs/Developers/subsonic-api.md
+++ b/content/en/docs/Developers/subsonic-api.md
@@ -22,6 +22,7 @@ between Navidrome and Subsonic:
   mention because, even though the Subsonic API 
   [schema](http://www.subsonic.org/pages/inc/api/schema/subsonic-rest-api-1.16.1.xsd) 
   specifies IDs as strings, some clients insist in converting IDs to integers
+* It is reccommended to follow the instructions for the [Airsonic API](https://airsonic.github.io/docs/api/) to authenticate when generating requests. 
 
 
 


### PR DESCRIPTION
Added link to https://airsonic.github.io/docs/api/ in bullets to reference more helpful documentation for generating requests. I struggled when only using the documentation on Subsonic's site, as it did not seem to be successful.