### PR TITLE
Point to main branch's .service file

### DIFF
--- a/content/en/docs/Installation/linux.md
+++ b/content/en/docs/Installation/linux.md
@@ -56,57 +56,8 @@ For additional configuration options see the [configuration options page](https:
 
 ### Create a Systemd Unit
 
-Create a new file under `/etc/systemd/system/` named `navidrome.service` with the following data.
-
-```toml
-[Unit]
-Description=Navidrome Music Server and Streamer compatible with Subsonic/Airsonic
-After=remote-fs.target network.target
-AssertPathExists=/var/lib/navidrome
-
-[Install]
-WantedBy=multi-user.target
-
-[Service]
-User=<user>
-Group=<group>
-Type=simple
-ExecStart=/opt/navidrome/navidrome --configfile "/var/lib/navidrome/navidrome.toml"
-WorkingDirectory=/var/lib/navidrome
-TimeoutStopSec=20
-KillMode=process
-Restart=on-failure
-
-# See https://www.freedesktop.org/software/systemd/man/systemd.exec.html
-DevicePolicy=closed
-NoNewPrivileges=yes
-PrivateTmp=yes
-PrivateUsers=yes
-ProtectControlGroups=yes
-ProtectKernelModules=yes
-ProtectKernelTunables=yes
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
-RestrictNamespaces=yes
-RestrictRealtime=yes
-SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap
-ReadWritePaths=/var/lib/navidrome
-
-# You can uncomment the following line if you're not using the jukebox This
-# will prevent navidrome from accessing any real (physical) devices
-#PrivateDevices=yes
-
-# You can change the following line to `strict` instead of `full` if you don't
-# want navidrome to be able to write anything on your filesystem outside of
-# /var/lib/navidrome.
-ProtectSystem=full
-
-# You can uncomment the following line if you don't have any media in /home/*.
-# This will prevent navidrome from ever reading/writing anything there.
-#ProtectHome=true
-
-# You can customize some Navidrome config options by setting environment variables here. Ex:
-#Environment=ND_BASEURL="/navidrome"
-```
+Create a new file under `/etc/systemd/system/` named `navidrome.service`.
+An example service file is available [on GitHub](https://github.com/navidrome/navidrome/blob/master/contrib/navidrome.service).
 
 ### Start the Navidrome Service
 


### PR DESCRIPTION
The current docs have some security issues that were fixed in the actual codebase (see navidrome/navidrome#677 for more context). Since future fixes may pop up, and novice users may not check GitHub - rather than having to duplicate the code in multiple places, we can link to the most up-to-date version.