### PR TITLE
Add link to lemmy community to user links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -155,6 +155,11 @@ no = 'Sorry to hear that. Please <a href="https://github.com/navidrome/website/i
 	url = "https://twitter.com/navidrome"
 	icon = "fab fa-twitter"
         desc = "Follow us on Twitter"
+[[params.links.user]]
+	name = "Lemmy (Community moderated)"
+	url = "https://discuss.tchncs.de/c/navidrome"
+	icon = "fa-regular fa-comment"
+        desc = "Discuss and help from fellow users on the fediverse"
 [[params.links.developer]]
 	name = "GitHub"
 	url = "https://github.com/navidrome/navidrome"


### PR DESCRIPTION
As per our short email exchange, here's a PR to add a link to the Lemmy community I set up earlier.  I hope I understood the website concept correctly, please tell me if I missed something.

Unfortunately, there's no official "Lemmy" icon in FontAwesome (yet), so I chose a generic "comment" icon, instead. There's an open issue at Font Awesome to add the Lemmy icon (https://github.com/FortAwesome/Font-Awesome/issues/19758), I will monitor the issue and update the icon once it is available.