### PR TITLE
Recommended Node version

### DIFF
--- a/content/en/docs/Installation/build-from-source.md
+++ b/content/en/docs/Installation/build-from-source.md
@@ -19,7 +19,7 @@ you should open an [issue in the project's GitHub page](https://github.com/navid
 If you don't want to wait, you can try to build the binary yourself, with the following steps.
 
 First, you will need to install [Go 1.19+](https://golang.org/doc/install) and
-[Node 16](http://nodejs.org). The setup is very strict, and the steps below only work with
+[Node 18](http://nodejs.org). The setup is very strict, and the steps below only work with
 these versions (enforced in the Makefile). Make sure to add `$GOPATH/bin` to your `PATH` as described
 in the [official Go site](https://golang.org/doc/gopath_code.html#GOPATH)
 


### PR DESCRIPTION
At this time the Makefile requires Node 18 to build Navidrome, while the website still says 16. This corrects that mistake. 