### PR TITLE
Update dev-environment.md

### DIFF
--- a/content/en/docs/Developers/dev-environment.md
+++ b/content/en/docs/Developers/dev-environment.md
@@ -22,7 +22,7 @@ Keep in mind that the overall experience when using Docker Desktop for developme
 ### Unix-based systems (Linux, macOS, BSD, …)
 
 1. Install [GoLang 1.20+](https://golang.org/doc/install)
-2. Install [Node 16](http://nodejs.org/)
+2. Install [Node 18](http://nodejs.org/)
 3. Install [TagLib](http://taglib.org)
     - Ubuntu: `sudo apt install libtag1-dev`
     - Arch Linux: `pacman -S taglib`

--- a/content/en/docs/Installation/build-from-source.md
+++ b/content/en/docs/Installation/build-from-source.md
@@ -18,8 +18,8 @@ you should open an [issue in the project's GitHub page](https://github.com/navid
 
 If you don't want to wait, you can try to build the binary yourself, with the following steps.
 
-First, you will need to install [Go 1.19+](https://golang.org/doc/install) and
-[Node 16](http://nodejs.org). The setup is very strict, and the steps below only work with
+First, you will need to install [Go 1.20+](https://golang.org/doc/install) and
+[Node 18](http://nodejs.org). The setup is very strict, and the steps below only work with
 these versions (enforced in the Makefile). Make sure to add `$GOPATH/bin` to your `PATH` as described
 in the [official Go site](https://golang.org/doc/gopath_code.html#GOPATH)
 


### PR DESCRIPTION
Building with node 16 gave the following error when running [make setup]:

`ERROR: Please check your Node version. Should be at least v18`

Update the docs to say node 18 instead