### PR TITLE
Add Apple TV client "SubSwift" to supported clients list

### DIFF
--- a/content/en/docs/Overview/_index.md
+++ b/content/en/docs/Overview/_index.md
@@ -105,6 +105,8 @@ Besides its own Web UI, Navidrome should be compatible with all Subsonic clients
 {{% /tab %}}
 
 {{% tab header="Other" %}}
+- Apple TV:
+  - [SubSwift](https://apps.apple.com/us/app/subswift/id6504658929)
 - Connected Speakers:
   - Sonos: [bonob](https://github.com/simojenki/bonob#readme)
   - Alexa: [AskSonic](https://github.com/srichter/asksonic#readme)


### PR DESCRIPTION
Add Apple TV client "SubSwift" to supported clients list under the "Other" tab in `Overview/_index.md`