### PR TITLE
Remove obsolete attribute version from the docker-compose.yml

### DIFF
--- a/content/en/docs/Installation/docker.md
+++ b/content/en/docs/Installation/docker.md
@@ -17,7 +17,6 @@ run Navidrome.
 Create a `docker-compose.yml` file with the following content (or add the `navidrome` service 
 below to your existing file):
 ```yaml
-version: "3"
 services:
   navidrome:
     image: deluan/navidrome:latest


### PR DESCRIPTION
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 

https://docs.docker.com/reference/compose-file/version-and-name/