### PR TITLE
Corrected typo in link to Airsonic Refix (Web)

### DIFF
--- a/content/en/docs/overview/_index.md
+++ b/content/en/docs/overview/_index.md
@@ -87,7 +87,7 @@ confirmed to work properly:
 {{% tab header="Web" %}}
 - [Feishin](https://feishin.vercel.app/)
 - [Thunderdrome](https://thunderdrome.netlify.app/)
-- [Airsonic Refix](https://airsonic.netlify.com/)
+- [Airsonic Refix](https://airsonic.netlify.app/)
 - [Aonsoku](https://aonsoku.vercel.app/)
 - [Subplayer](https://subplayer.netlify.app/)
 - [Aurial](https://shrimpza.github.io/aurial/)


### PR DESCRIPTION
The .com link yields a 404 while the .app links works.