### PR TITLE
docs(installation): Update golang requirement

### DIFF
--- a/content/en/docs/installation/build-from-source.md
+++ b/content/en/docs/installation/build-from-source.md
@@ -18,7 +18,7 @@ you should open an [issue in the project's GitHub page](https://github.com/navid
 
 If you don't want to wait, you can try to build the binary yourself, with the following steps.
 
-First, you will need to install [Go 1.22+](https://golang.org/doc/install) and
+First, you will need to install [Go 1.24+](https://golang.org/doc/install) and
 [Node 20+](https://nodejs.org/en/download). The setup is very strict, and the steps below only work with
 these versions (enforced in the Makefile). Make sure to add `$GOPATH/bin` to your `PATH` as described
 in the [official Go site](https://golang.org/doc/gopath_code.html#GOPATH)


### PR DESCRIPTION
The golang requirement for building from source was out of date, we now require 1.24+ (as of 0.55.2 https://github.com/navidrome/navidrome/blob/v0.55.2/go.mod#L3 specifies 1.24.1)