### PR TITLE
Fix: Update render-heading.html for Hugo 0.147.x compatibility

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,1 +1,7 @@
-{{ template "_default/_markup/td-render-heading.html" . }}
+{{- /* Render link for every non-empty heading */ -}}
+{{- $context := . -}}
+{{- $id := .Anchor -}}
+<h{{ .Level }} id="{{ $id }}" {{- with .Attributes.class }} class="{{ . }}" {{- end -}}>
+{{- .Text | safeHTML -}}
+<a class="td-heading-self-link" href="#{{ $id }}" aria-label="Heading self-link"></a>
+</h{{ .Level }}>


### PR DESCRIPTION
This PR fixes the following error when using Hugo 0.147.x:

```
site-1  | Error: html/template:_markup/render-heading.html:1:12: no such template "_default/_markup/td-render-heading.html"
```

## Problem
Hugo 0.147.x changed how template lookup works for render hooks, causing template references like `{{ template "_default/_markup/td-render-heading.html" . }}` to fail.

## Solution
I replaced the template reference with the actual implementation code to render headings with self-links, which is compatible with both older Hugo versions and 0.147.x.

This fix is based on the issue reported in the Docsy theme repository: https://github.com/google/docsy/issues/2214