### PR TITLE
Specify multilibrary file structure more clearly

### DIFF
--- a/content/en/docs/usage/multi-library.md
+++ b/content/en/docs/usage/multi-library.md
@@ -92,11 +92,13 @@ Each library should have its own root folder structure:
 ├── Author 2/
 └── ...
 
-/music/lossless/       # High-quality library
+/other_path/lossless/       # High-quality library
 ├── Artist 1/
 ├── Artist 2/
 └── ...
 ```
+
+It is up to the user where to save music collections. You can store your artists in `/music` or any other path you want to use.
 
 ### Permissions
 


### PR DESCRIPTION
The example made it unclear, whether all libraries have to be in /music or whether there can be custom paths. 

This was discussed in [Navidrome discussion](https://github.com/navidrome/navidrome/discussions/4429).