### PR TITLE
Update multi-library.md with a systemd config pitfall.

### DIFF
--- a/content/en/docs/usage/multi-library.md
+++ b/content/en/docs/usage/multi-library.md
@@ -146,6 +146,7 @@ Most Subsonic-compatible clients that support multiple music folders will work w
 - Verify the path exists and is readable by the Navidrome user
 - Check the logs for permission errors
 - Ensure the path doesn't overlap with other libraries
+- If using systemd, like on NixOS, ensure that each library folder is listed in the `BindReadOnlyPath` path.
 
 ### User Cannot Access Library
 


### PR DESCRIPTION
Addresses the NixOS config that limits access to only the MusidFolder, add called out by  @mikebirdgeneau  https://github.com/navidrome/navidrome/issues/4595#issuecomment-3619331908