### PR TITLE
Updated ferrosonic to point at actively maintained repo

### DIFF
--- a/assets/apps/ferrosonic/index.yaml
+++ b/assets/apps/ferrosonic/index.yaml
@@ -1,12 +1,12 @@
 name: Ferrosonic
-url: https://github.com/jaidaken/ferrosonic
+url: https://github.com/Jamie098/ferrosonic-ng
 platforms:
   linux: true
 api: Subsonic
 description: "A terminal-based Subsonic music client written in Rust, featuring bit-perfect audio with automatic PipeWire sample rate switching, gapless playback, MPRIS2 desktop media controls, and an integrated cava audio visualizer."
 screenshots:
   thumbnail: thumbnail.webp
-repoUrl: https://github.com/jaidaken/ferrosonic
+repoUrl: https://github.com/Jamie098/ferrosonic-ng
 isFree: true
 keywords:
   - terminal


### PR DESCRIPTION
Updated the `url` and `repoUrl` fields in `assets/apps/ferrosonic/index.yaml` to reference the actively maintained GitHub repository (`https://github.com/Jamie098/ferrosonic-ng`) instead of the old one (`https://github.com/jaidaken/ferrosonic`).

This can be reverted if and when the original Ferrosonic becomes active. Currently https://github.com/jaidaken/ferrosonic points to https://github.com/Jamie098/ferrosonic-ng in the readme so it makes sense to update this too.