### PR TITLE
docs: add Navidrome CLI reference and link from configuration options

### DIFF
--- a/content/en/docs/usage/admin/cli.md
+++ b/content/en/docs/usage/admin/cli.md
@@ -45,6 +45,8 @@ navidrome -c /etc/navidrome/navidrome.toml --nobanner
 
 ## Command overview
 
+The built-in top-level administrative commands are: `inspect`, `scan`, `backup`, `pls`, `service`, and `user`.
+
 ### `inspect`
 
 Inspect music file tags as Navidrome sees them.
@@ -134,6 +136,47 @@ navidrome backup prune --keep-count 7
 # Restore from a specific backup file (offline only)
 navidrome backup restore --backup-file /backups/navidrome.db.2026-04-01-040000
 ```
+
+
+---
+
+### `pls` (playlist export)
+
+Export playlists to M3U and list playlists from the CLI.
+
+```bash
+navidrome pls --playlist <playlist-name-or-id>
+```
+
+Useful flags:
+
+- `-p, --playlist` (required): Playlist name or ID
+- `-o, --output`: Output file path (`-` or omitted writes to stdout)
+
+Examples:
+
+```bash
+# Export a playlist to stdout
+navidrome pls --playlist "Road Trip Mix"
+
+# Export a playlist to a file
+navidrome pls --playlist "Road Trip Mix" --output ./road-trip.m3u8
+```
+
+`pls` also includes a `list` subcommand to enumerate playlists:
+
+```bash
+# List all playlists (CSV)
+navidrome pls list
+
+# List playlists for a specific user as JSON
+navidrome pls list --user alice --format json
+```
+
+`pls list` flags:
+
+- `-u, --user`: Filter by username or user ID
+- `-f, --format`: Output format (`csv` or `json`, default: `csv`)
 
 ---
 

--- a/content/en/docs/usage/admin/cli.md
+++ b/content/en/docs/usage/admin/cli.md
@@ -1,0 +1,209 @@
+---
+title: "Command-Line Interface (CLI)"
+linkTitle: "CLI"
+date: 2026-04-19
+weight: 15
+description: >
+  Reference for Navidrome command-line commands and common workflows
+---
+
+Navidrome includes a built-in CLI for administration tasks, maintenance, and troubleshooting.
+
+## Quick start
+
+Use the built-in help:
+
+```bash
+navidrome --help
+```
+
+Get help for a specific command:
+
+```bash
+navidrome <command> --help
+navidrome <command> <subcommand> --help
+```
+
+## Global flags
+
+These flags are available across commands:
+
+- `-c, --configfile`: Load a specific config file
+- `-n, --nobanner`: Disable startup banner
+- `--musicfolder`, `--datafolder`, `--cachefolder`
+- `-l, --loglevel`, `--logfile`
+
+Example:
+
+```bash
+navidrome -c /etc/navidrome/navidrome.toml --nobanner
+```
+
+## Command overview
+
+### `inspect`
+
+Inspect music file tags as Navidrome sees them.
+
+```bash
+navidrome inspect <file1> [file2 ...]
+```
+
+Supported output formats (`-f, --format`):
+
+- `pretty`
+- `toml`
+- `yaml`
+- `json`
+- `jsonindent` (default)
+
+Example:
+
+```bash
+navidrome inspect --format yaml "/music/Artist/Album/Track01.flac"
+```
+
+---
+
+### `scan`
+
+Run a library scan from the CLI.
+
+```bash
+navidrome scan
+```
+
+Useful flags:
+
+- `-f, --full`: Ignore timestamps and check all subfolders
+- `-t, --target`: Scan specific folders using `libraryID:folderPath` pairs (repeatable)
+- `--target-file`: Read targets from a file (one `libraryID:folderPath` per line)
+
+Examples:
+
+```bash
+# Full scan
+navidrome scan --full
+
+# Scan only selected folders
+navidrome scan -t 1:Music/Rock -t 2:Audiobooks
+
+# Read scan targets from file
+navidrome scan --target-file ./scan-targets.txt
+```
+
+---
+
+### `backup` (alias: `bkp`)
+
+Manage database backups.
+
+```bash
+navidrome backup --help
+```
+
+Subcommands:
+
+- `navidrome backup create`
+- `navidrome backup prune`
+- `navidrome backup restore`
+
+Common flags:
+
+- `backup create`: `-d, --backup-dir`
+- `backup prune`: `-d, --backup-dir`, `-k, --keep-count`, `-f, --force`
+- `backup restore`: `-b, --backup-file` (required), `-f, --force`
+
+{{% alert color="warning" title="Important" %}}
+`navidrome backup restore` must be run while Navidrome is **not running**.
+{{% /alert %}}
+
+Examples:
+
+```bash
+# Create a backup in the configured backup path
+navidrome backup create
+
+# Prune and keep only the newest 7 backups
+navidrome backup prune --keep-count 7
+
+# Restore from a specific backup file (offline only)
+navidrome backup restore --backup-file /backups/navidrome.db.2026-04-01-040000
+```
+
+---
+
+### `service` (alias: `svc`)
+
+Manage Navidrome as an OS service.
+
+```bash
+navidrome service --help
+# same as: navidrome svc --help
+```
+
+Subcommands:
+
+- `install`
+- `uninstall`
+- `start`
+- `stop`
+- `status`
+- `execute`
+
+Example:
+
+```bash
+# Install as a service
+navidrome svc install
+
+# Start and verify status
+navidrome svc start
+navidrome svc status
+```
+
+{{% alert %}}
+The `service` command is mainly intended for native OS service setups. In containerized deployments, lifecycle is usually managed by Docker/Compose/Kubernetes instead.
+{{% /alert %}}
+
+---
+
+### `user`
+
+Administer Navidrome users from the CLI.
+
+```bash
+navidrome user --help
+```
+
+Subcommands:
+
+- `create` (alias: `c`)
+- `delete` (alias: `d`)
+- `edit` (alias: `e`)
+- `list`
+
+Examples:
+
+```bash
+# Create an admin user
+navidrome user create --username alice --email alice@example.com --admin
+
+# Edit user role
+navidrome user edit --user alice --set-regular
+
+# Update password interactively
+navidrome user edit --user alice --set-password
+
+# List users as JSON
+navidrome user list --format json
+
+# Delete user by username or ID
+navidrome user delete --user alice
+```
+
+## Notes and best practices
+
+- Use `--help` frequently: command options can evolve between releases.
+- Prefer explicit `--configfile` when running administrative commands in scripts.
+- For destructive operations (`backup restore`, aggressive `backup prune`), verify paths and make an extra copy first.

--- a/content/en/docs/usage/admin/cli.md
+++ b/content/en/docs/usage/admin/cli.md
@@ -9,6 +9,9 @@ description: >
 
 Navidrome includes a built-in CLI for administration tasks, maintenance, and troubleshooting.
 
+This page reflects the command definitions in the Navidrome source (`cmd/root.go`, `cmd/inspect.go`, `cmd/scan.go`, `cmd/backup.go`, `cmd/svc.go`, and `cmd/user.go`) in `github.com/navidrome/navidrome`.
+
+
 ## Quick start
 
 Use the built-in help:
@@ -23,6 +26,8 @@ Get help for a specific command:
 navidrome <command> --help
 navidrome <command> <subcommand> --help
 ```
+
+If you run `navidrome` with no subcommand, it starts the server.
 
 ## Global flags
 
@@ -104,9 +109,9 @@ navidrome backup --help
 
 Subcommands:
 
-- `navidrome backup create`
-- `navidrome backup prune`
-- `navidrome backup restore`
+- `navidrome backup create` (alias: `c`)
+- `navidrome backup prune` (alias: `p`)
+- `navidrome backup restore` (alias: `r`)
 
 Common flags:
 
@@ -163,7 +168,7 @@ navidrome svc status
 ```
 
 {{% alert %}}
-The `service` command is mainly intended for native OS service setups. In containerized deployments, lifecycle is usually managed by Docker/Compose/Kubernetes instead.
+The `service` command is mainly intended for native OS service setups. In containerized deployments, lifecycle is typically managed by Docker/Compose/Kubernetes instead.
 {{% /alert %}}
 
 ---

--- a/content/en/docs/usage/admin/cli.md
+++ b/content/en/docs/usage/admin/cli.md
@@ -9,8 +9,7 @@ description: >
 
 Navidrome includes a built-in CLI for administration tasks, maintenance, and troubleshooting.
 
-This page reflects the command definitions in the Navidrome source (`cmd/root.go`, `cmd/inspect.go`, `cmd/scan.go`, `cmd/backup.go`, `cmd/svc.go`, and `cmd/user.go`) in `github.com/navidrome/navidrome`.
-
+Use this page as a practical reference for common command-line workflows and examples.
 
 ## Quick start
 

--- a/content/en/docs/usage/configuration/options.md
+++ b/content/en/docs/usage/configuration/options.md
@@ -115,6 +115,8 @@ $ navidrome --musicfolder "/mnt/music"
 Please note that command line arguments must be **all lowercase**. For a list of all available command line options,
 just call `navidrome --help`.
 
+For command and workflow examples (scan, inspect, backups, users, service management), see the [CLI reference](/docs/usage/admin/cli/).
+
 ## Environment Variables
 
 Any configuration option can be set as an environment variable, just add a the prefix `ND_` and


### PR DESCRIPTION
### Motivation

- Provide an authoritative, centralized reference for Navidrome's built-in CLI to help admins run common workflows and maintenance tasks.
- Document commonly used commands and flags (inspect, scan, backup, service/svc, user) with examples and safety warnings to reduce operator error.
- Surface CLI guidance from the configuration page so users discovering `--help` options can quickly find detailed workflows.

### Description

- Added a new documentation page `content/en/docs/usage/admin/cli.md` containing CLI reference, global flags, command overviews, examples, and safety notes for `inspect`, `scan`, `backup` (create/prune/restore), `service`/`svc`, and `user` commands.
- Updated `content/en/docs/usage/configuration/options.md` to add a cross-link to the new CLI reference from the command-line arguments section.
- Included practical examples and an explicit warning that `navidrome backup restore` must be run while the service is not running.
- This is a documentation-only change and does not modify application code or database schema.

### Testing

- No automated tests or linters were run because this is a documentation-only change per repository guidance. 
- Git operations were used to stage and commit the files locally, and the commit contains only the new `cli.md` and the small `options.md` cross-link edit.
- No behavioral changes were introduced, so no runtime verification was necessary for this PR.

