### PR TITLE
Improve security baseline of extauth examples

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -208,7 +208,7 @@ Navidrome imports `.m3u` playlists from your music folder, but only after an adm
 Now that Navidrome is running, explore these features:
 
 - **[Multi-Library Support](/docs/usage/features/multi-library/):** Organize multiple music collections (audiobooks, family libraries) with separate access controls
-- **[External Authentication](/docs/usage/configuration/authentication/):** Integrate with your homelab SSO or external auth system
+- **[Externalized Authentication](/docs/usage/integration/authentication/):** Integrate with your homelab SSO or external auth system
 - **[Configuration Options](/docs/usage/configuration/options/):** Customize scanning, transcoding, and more
 - **[Client Apps](/apps/):** Connect mobile apps, desktop players, and more
 

--- a/content/en/docs/getting-started/extauth-quickstart.md
+++ b/content/en/docs/getting-started/extauth-quickstart.md
@@ -130,6 +130,9 @@ This example shows Navidrome behind Caddy with Authentik for authentication.
 
 ```Caddyfile
 example.com {
+   # Remove any client-supplied user header
+   request_header -Remote-User
+
    # Authentik output endpoint
    reverse_proxy /outpost.goauthentik.io/* http://authentik:9000
 

--- a/content/en/docs/getting-started/extauth-quickstart.md
+++ b/content/en/docs/getting-started/extauth-quickstart.md
@@ -180,7 +180,7 @@ services:
 
 ## Security Considerations
 
-Make sure to check the [Security Considerations](../security#externalized-authentication) page for important security information.
+Make sure to check the [Security Considerations](/docs/usage/admin/security/#externalized-authentication) page for important security information.
 
 Key security points:
 * Never run Navidrome as root
@@ -222,6 +222,6 @@ A: Yes, Navidrome will fall back to standard authentication if the reverse proxy
 
 - [Security Considerations](/docs/usage/admin/security) for Navidrome
 - [Configuration Options](/docs/usage/configuration/options) for all available settings
-- [Externalized Authentication](/docs/usage/configuration/authentication/) for the detailed documentation of the feature
+- [Externalized Authentication](/docs/usage/integration/authentication/) for the detailed documentation of the feature
 - [Caddy Forward Auth documentation](https://caddyserver.com/docs/caddyfile/directives/forward_auth)
 - [Traefik ForwardAuth middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/)

--- a/content/en/docs/getting-started/extauth-quickstart.md
+++ b/content/en/docs/getting-started/extauth-quickstart.md
@@ -184,12 +184,10 @@ services:
 
 ## Security Considerations
 
-{{< alert title="Security Note" color="warning" >}}
-**Key security principle for externalized authentication**
-
+{{< alert title="Key Security Principle" color="primary" >}}
 When you enable externalized authentication by configuring trusted sources, you must ensure that all the trusted sources are configured to:
 
-1. Not let untrusted clients set the user header themselves.
+1. Not let untrusted clients set the user header themselves (i.e. remove the header if they do).
 2. Not set the header if the request is not authenticated (e.g. when the authentication is bypassed for the subsonic endpoints).
 {{< /alert >}}
 

--- a/content/en/docs/getting-started/extauth-quickstart.md
+++ b/content/en/docs/getting-started/extauth-quickstart.md
@@ -162,23 +162,36 @@ services:
       traefik.http.middlewares.authelia.forwardauth.address: http://authelia:9091/api/verify?rd=https://auth.example.com/
       traefik.http.middlewares.authelia.forwardauth.authResponseHeaders: Remote-User
 
+      # Security middleware for the entrypoints
+      traefik.http.middlewares.drop-untrusted-auth-headers.headers.customrequestheaders.Remote-User:
+
   navidrome:
     image: deluan/navidrome:0.52.0
     labels:
       # Main Navidrome access with web authentication
       traefik.http.routers.navidrome.rule: Host(`music.example.com`)
       traefik.http.routers.navidrome.entrypoints: https
-      traefik.http.routers.navidrome.middlewares: authelia@docker
+      traefik.http.routers.navidrome.middlewares: drop-untrusted-auth-headers@docker,authelia@docker
 
       # Authentication bypass for share and subsonic endpoints
       traefik.http.routers.navidrome-public.rule: Host(`music.example.com`) && (PathPrefix(`/share/`) || PathPrefix(`/rest/`))
       traefik.http.routers.navidrome-public.entrypoints: https
+      traefik.http.routers.navidrome-public.middlewares: drop-untrusted-auth-headers@docker
     environment:
       # Trust all IPs in Docker network - use more specific IP if possible
       ND_EXTAUTH_TRUSTEDSOURCES: 0.0.0.0/0
 ```
 
 ## Security Considerations
+
+{{< alert title="Security Note" color="warning" >}}
+**Key security principle for externalized authentication**
+
+When you enable externalized authentication by configuring trusted sources, you must ensure that all the trusted sources are configured to:
+
+1. Not let untrusted clients set the user header themselves.
+2. Not set the header if the request is not authenticated (e.g. when the authentication is bypassed for the subsonic endpoints).
+{{< /alert >}}
 
 Make sure to check the [Security Considerations](/docs/usage/admin/security/#externalized-authentication) page for important security information.
 

--- a/content/en/docs/usage/integration/authentication.md
+++ b/content/en/docs/usage/integration/authentication.md
@@ -63,7 +63,7 @@ Note that if you don't intend to support third-party subsonic clients, you can s
 
 ## Security
 
-Make sure to check the externalized authentication section in the dedicated [Security Considerations](../security#externalized-authentication) page.
+Make sure to check the externalized authentication section in the dedicated [Security Considerations](/docs/usage/admin/security/#externalized-authentication) page.
 
 ## Examples
 

--- a/content/en/docs/usage/integration/authentication.md
+++ b/content/en/docs/usage/integration/authentication.md
@@ -63,6 +63,13 @@ Note that if you don't intend to support third-party subsonic clients, you can s
 
 ## Security
 
+{{< alert title="Key Security Principle" color="primary" >}}
+When you enable externalized authentication by configuring trusted sources, you must ensure that all the trusted sources are configured to:
+
+1. Not let untrusted clients set the user header themselves (i.e. remove the header if they do).
+2. Not set the header if the request is not authenticated (e.g. when the authentication is bypassed for the subsonic endpoints).
+{{< /alert >}}
+
 Make sure to check the externalized authentication section in the dedicated [Security Considerations](/docs/usage/admin/security/#externalized-authentication) page.
 
 ## Examples

--- a/content/en/docs/usage/integration/authentication.md
+++ b/content/en/docs/usage/integration/authentication.md
@@ -86,6 +86,9 @@ In this example, Navidrome is behind the [Caddy](https://caddyserver.com) revers
 ```Caddyfile
 example.com
 
+# Remove any client-supplied user header
+request_header -Remote-User
+
 reverse_proxy /outpost.goauthentik.io/* http://authentik:9000
 
 @protected not path /share/* /rest/*

--- a/content/en/docs/usage/integration/authentication.md
+++ b/content/en/docs/usage/integration/authentication.md
@@ -148,6 +148,8 @@ services:
       # Basicauth middleware for subsonic clients
       traefik.http.middlewares.authelia-basicauth.forwardauth.address: http://authelia:9091/api/verify?auth=basic
       traefik.http.middlewares.authelia-basicauth.forwardauth.authResponseHeaders: Remote-User
+      # Security middleware for the entrypoints
+      traefik.http.middlewares.drop-untrusted-auth-headers.headers.customrequestheaders.Remote-User:
 
   navidrome:
     image: deluan/navidrome:0.52.0
@@ -157,13 +159,13 @@ services:
       # authentication for /share/* URLs, so you don't need an extra rule here.
       traefik.http.routers.navidrome.rule: Host(`music.example.com`)
       traefik.http.routers.navidrome.entrypoints: https
-      traefik.http.routers.navidrome.middlewares: authelia@docker
+      traefik.http.routers.navidrome.middlewares: drop-untrusted-auth-headers@docker,authelia@docker
       # Requests to the subsonic endpoint use the basicauth middleware, unless
       # they come from the Navidrome Web App ("NavidromeUI" subsonic client), in
       # which case the default authelia middleware is used.
       traefik.http.routers.navidrome-subsonic.rule: Host(`music.example.com`) && PathPrefix(`/rest/`) && !Query(`c`, `NavidromeUI`)
       traefik.http.routers.navidrome-subsonic.entrypoints: https
-      traefik.http.routers.navidrome-subsonic.middlewares: authelia-basicauth@docker
+      traefik.http.routers.navidrome-subsonic.middlewares: drop-untrusted-auth-headers@docker,authelia-basicauth@docker
     environment:
       # Navidrome does not resolve hostnames in this option, and by default
       # traefik will get assigned an IP address dynamically, so all IPs must be
@@ -176,5 +178,7 @@ services:
       # manage their password in Navidrome anymore.
       ND_ENABLEUSEREDITING: false
 ```
+
+We recommended applying the `drop-untrusted-auth-headers` [on the entrypoints](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#httpmiddlewares) if possible (instead of configuring it on each service individually as shown here).
 
 If you want to add support for the subsonic authentication scheme in order to support all subsonic clients, you can have a look at the Traefik plugin [BasicAuth adapter for Subsonic](https://plugins.traefik.io/plugins/6521c6de39e2d7caa2181888/basic-auth-adapter-for-subsonic) which transforms subsonic authentication parameters into a BasicAuth header that Authelia can handle, and performs the error response rewriting.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,15 +1,20 @@
 services:
   site:
-    image: floryn90/hugo:0.153.0-ext-ubuntu
+    image: docker.io/floryn90/hugo:0.153.0-ext-ubuntu
     entrypoint: ["/bin/sh", "-c"]
-    command: ["./fetch-charts.sh && hugo server"]
+    command: ["./fetch-charts.sh && hugo server --noBuildLock"]
     ports:
-      - "1313:1313"
+      - 127.0.0.1:1313:1313
     environment:
-      - HUGO_CACHEDIR=/tmp/hugo_cache
+      - HUGO_CACHEDIR=/tmp/hugo/cache
+      - HUGO_RESOURCEDIR=/tmp/hugo/resources
+      - HUGO_PUBLISHDIR=/tmp/hugo/public
       - CHARTS_URL
       - CHARTS_API_KEY
     #      - HUGO_ENV=production
     volumes:
-      - .:/src
-      - ./.hugo_cache:/tmp/hugo_cache
+      - .:/src:ro
+      - hugo:/tmp/hugo
+
+volumes:
+  hugo:


### PR DESCRIPTION
Following a discussion in https://github.com/navidrome/navidrome/issues/5146, I figured that the documentation could be more explicit regarding the handling of the user header.

This PR adds explicit configuration to the examples for removing client-supplied user headers, as well as a highlight of the principle in the security section of the two guides.