### PR TITLE
Update listed node versions to v24

### DIFF
--- a/content/en/docs/developers/dev-environment.md
+++ b/content/en/docs/developers/dev-environment.md
@@ -23,7 +23,7 @@ Keep in mind that the overall experience when using Docker Desktop for developme
 ### Unix-based systems (Linux, macOS, BSD, …)
 
 1. Install [GoLang 1.23+](https://golang.org/doc/install)
-2. Install [Node 20](http://nodejs.org/)
+2. Install [Node 24](http://nodejs.org/)
 3. Install [TagLib 2.0+](https://github.com/taglib/taglib/blob/master/INSTALL.md)
     - Arch Linux: `pacman -S taglib`
     - macOS: `brew install taglib --HEAD`

--- a/content/en/docs/installation/build-from-source.md
+++ b/content/en/docs/installation/build-from-source.md
@@ -19,7 +19,7 @@ you should open an [issue in the project's GitHub page](https://github.com/navid
 If you don't want to wait, you can try to build the binary yourself, with the following steps.
 
 First, you will need to install [Go 1.24+](https://golang.org/doc/install) and
-[Node 20+](https://nodejs.org/en/download). The setup is very strict, and the steps below only work with
+[Node 24+](https://nodejs.org/en/download). The setup is very strict, and the steps below only work with
 these versions (enforced in the Makefile). Make sure to add `$GOPATH/bin` to your `PATH` as described
 in the [official Go site](https://golang.org/doc/gopath_code.html#GOPATH)
 


### PR DESCRIPTION
Resolves #342 

### Motivation
- Provide accurate [dev-environment](https://www.navidrome.org/docs/developers/dev-environment/) and [build-from-source](https://www.navidrome.org/docs/installation/build-from-source/) instructions by referencing the correct node version (v24).

### Description
- Replaced reference to `Node 20` with `Node 24` in `content/en/docs/developers/dev-environment.md`.
- Replaced reference to `Node 20+` with `Node 24+` in `content/en/docs/installation/build-from-source.md`.

### Testing
- No automated tests or linters were run because this is a documentation-only change per the project policy for docs changes.
- Navidrome website was run locally (via `docker compose up --build`) to validate changes:
<img width="1495" height="763" alt="Screenshot 2026-04-26 at 3 07 13 AM" src="https://github.com/user-attachments/assets/c62ed1be-c691-4da2-a02f-ba3597afbeae" />
<img width="1495" height="763" alt="Screenshot 2026-04-26 at 3 06 28 AM" src="https://github.com/user-attachments/assets/935facf2-1ed5-481f-b4c0-bc960c117f11" />

