### PR TITLE
docs: add macOS bind mount caveat for Docker installation

### DIFF
--- a/content/en/docs/installation/docker.md
+++ b/content/en/docs/installation/docker.md
@@ -65,4 +65,4 @@ When running Navidrome on Docker Desktop for macOS, using a host bind mount for 
 
 This appears to be related to the filesystem translation layer between macOS (APFS) and the Linux filesystem used inside the Docker VM (via VirtioFS / shared file systems). Under heavy or frequent disk activity (e.g. SQLite writes or library scanning), some users have reported instability or I/O errors.
 
-A more reliable alternative on macOS is to use a Docker-managed volume for `/data`
+A more reliable alternative on macOS is to use a Docker-managed volumes.

--- a/content/en/docs/installation/docker.md
+++ b/content/en/docs/installation/docker.md
@@ -58,3 +58,11 @@ $ docker run -d \
   file. For `docker` cli use the `-e` parameter. Ex: `-e ND_SESSIONTIMEOUT=24h`.
 - If you want to use a [configuration file](/docs/usage/configuration/options/#configuration-file) with Navidrome running in Docker,
   you can create a `navidrome.toml` config file in the `/data` folder and set the option `ND_CONFIGFILE=/data/navidrome.toml`.
+
+### MacOS Docker Desktop: bind mount caveat
+
+When running Navidrome on Docker Desktop for macOS, using a host bind mount for the `/data` and `/music` directories may lead to filesystem-related issues such as disk I/O errors under certain workloads.
+
+This appears to be related to the filesystem translation layer between macOS (APFS) and the Linux filesystem used inside the Docker VM (via VirtioFS / shared file systems). Under heavy or frequent disk activity (e.g. SQLite writes or library scanning), some users have reported instability or I/O errors.
+
+A more reliable alternative on macOS is to use a Docker-managed volume for `/data`


### PR DESCRIPTION
Issues reported here:

1. https://github.com/navidrome/navidrome/issues/3669
2. https://github.com/navidrome/navidrome/issues/5536
3. https://github.com/navidrome/navidrome/issues/4830

 are most likely caused by this problem with mac os docker:

Docker for Mac: VirtioFS file corruption with heavy disk activity - https://github.com/docker/for-mac/issues/6690
Docker for Mac: File corruption VirtioFS and gRPC bind mount 4.36.0 - https://github.com/docker/for-mac/issues/7494
SQLite user forum, disk I/O errors on qemu virtfs - https://sqlite.org/forum/forumpost/6a0e396a2b8aa8e56001ddc1c618b90bee37465b7f47dc978f456b71d9525949

I am updating the documentation to warn users against using host mounts on docker installations as requested by deluan here: https://discord.com/channels/671335427726114836/704303730660737113/1509212940421824604