### PR TITLE
docs: add configuration precedence note to options page

### DIFF
--- a/content/en/docs/usage/configuration/options.md
+++ b/content/en/docs/usage/configuration/options.md
@@ -12,6 +12,8 @@ aliases:
 Navidrome allows some customization using environment variables, loading from a configuration file
 or using command line arguments.
 
+When the same option is set using multiple methods, Navidrome uses the following order of precedence (highest to lowest): environment variables, command line arguments, configuration file.
+
 ## Configuration File
 
 {{< alert >}}
@@ -304,3 +306,4 @@ make it all uppercase. Ex: `ND_LOGLEVEL=debug`. See below for all available opti
 [opensubsonic]: https://opensubsonic.netlify.app/
 [backup]: /docs/usage/admin/backup
 [plugins]: /docs/usage/features/plugins
+


### PR DESCRIPTION
The configuration options page mentions that Navidrome supports environment variables, configuration files, and command line arguments, but does not explain which takes precedence when the same option is set using more than one method.

This PR adds a short note clarifying the order of precedence: environment variables > command line arguments > configuration file.

Fixes #339