### PR TITLE
docs: drop TagLib/pkg-config build deps, bump Go/Node versions

### DIFF
--- a/content/en/docs/developers/dev-environment.md
+++ b/content/en/docs/developers/dev-environment.md
@@ -22,18 +22,12 @@ Keep in mind that the overall experience when using Docker Desktop for developme
 
 ### Unix-based systems (Linux, macOS, BSD, …)
 
-1. Install [GoLang 1.23+](https://golang.org/doc/install)
+1. Install [GoLang 1.26+](https://golang.org/doc/install)
 2. Install [Node 24](http://nodejs.org/)
-3. Install [TagLib 2.0+](https://github.com/taglib/taglib/blob/master/INSTALL.md)
-    - Arch Linux: `pacman -S taglib`
-    - macOS: `brew install taglib --HEAD`
-    - For other platforms check their [installation instructions](https://github.com/taglib/taglib/blob/master/INSTALL.md)
-
-4. Install `pkg-config`
-5. Clone the project from https://github.com/navidrome/navidrome
-6. Install development tools: `make setup`. This may take a while to complete
-7. Test installation: `make build`. This command should create a `navidrome` executable in the project's folder
-8. Create a `navidrome.toml` config file in the project's folder with ([at least](/docs/usage/configuration/options/#available-options)) the following options:
+3. Clone the project from https://github.com/navidrome/navidrome
+4. Install development tools: `make setup`. This may take a while to complete
+5. Test installation: `make build`. This command should create a `navidrome` executable in the project's folder
+6. Create a `navidrome.toml` config file in the project's folder with ([at least](/docs/usage/configuration/options/#available-options)) the following options:
 ```toml
 # Set your music folder, preferable a specific development music library with few songs,
 # to make scan fast

--- a/content/en/docs/installation/build-from-source.md
+++ b/content/en/docs/installation/build-from-source.md
@@ -18,17 +18,10 @@ you should open an [issue in the project's GitHub page](https://github.com/navid
 
 If you don't want to wait, you can try to build the binary yourself, with the following steps.
 
-First, you will need to install [Go 1.24+](https://golang.org/doc/install) and
-[Node 24+](https://nodejs.org/en/download). The setup is very strict, and the steps below only work with
+First, you will need to install [Go 1.26+](https://golang.org/doc/install) and
+[Node 24](https://nodejs.org/en/download). The setup is very strict, and the steps below only work with
 these versions (enforced in the Makefile). Make sure to add `$GOPATH/bin` to your `PATH` as described
 in the [official Go site](https://golang.org/doc/gopath_code.html#GOPATH)
-
-You'll also need to install the [TagLib](http://taglib.org) library:
-- Debian/Ubuntu: `sudo apt install libtag1-dev`
-- Arch Linux: `pacman -S taglib`
-- macOS: `brew install taglib`
-- FreeBSD: `pkg install taglib`
-- For other platforms check their [installation instructions](https://github.com/taglib/taglib/blob/master/INSTALL.md)
 
 After the prerequisites above are installed, clone Navidrome's repository and build it:
 


### PR DESCRIPTION
## Summary

Navidrome now reads tags via [`go.senan.xyz/taglib`](https://go.senan.xyz/taglib), a pure-Go WASM (wazero) binding. As a result, building from source no longer requires a system TagLib library or `pkg-config` — the Makefile's `check_env` validates only Go and Node.

These docs were still telling people to install TagLib and `pkg-config`, and listed stale Go/Node versions.

## Changes

**`installation/build-from-source.md`**
- Remove the "install TagLib" block (Debian/Ubuntu, Arch, macOS, FreeBSD commands)
- Go 1.24+ → **1.26+**, Node 24+ → **24**

**`developers/dev-environment.md`**
- Remove the TagLib 2.0+ and `pkg-config` steps; renumber the list
- GoLang 1.23+ → **1.26+**

## Notes

- Versions verified against the main repo: `go.mod` (Go 1.26) and `.nvmrc` (v24).
- **ffmpeg is unchanged** — it's still an external runtime binary, so its requirement note stays.
- TagLib mentions in `faq/_index.md` and `persistent-ids.md` are left untouched: they describe the library's runtime behavior (how metadata is read), not an install step.
- The dev-container already only installs ffmpeg + Node — no doc change needed there.