### PR TITLE
docs: document the navidrome plugin CLI command

### DIFF
--- a/content/en/docs/usage/admin/cli.md
+++ b/content/en/docs/usage/admin/cli.md
@@ -92,7 +92,7 @@ navidrome -c /etc/navidrome/navidrome.toml --nobanner
 
 ## Command overview
 
-The built-in top-level administrative commands are: `inspect`, `scan`, `backup`, `pls`, `service`, and `user`.
+The built-in top-level administrative commands are: `inspect`, `scan`, `backup`, `pls`, `service`, `user`, and `plugin`.
 
 ### `inspect`
 
@@ -295,6 +295,71 @@ navidrome user list --format json
 # Delete user by username or ID
 navidrome user delete --user alice
 ```
+
+---
+
+### `plugin`
+
+Manage and inspect plugins from the CLI.
+
+```bash
+navidrome plugin --help
+```
+
+Subcommands:
+
+- `list`: List installed plugins
+- `info`: Show details for an installed plugin or a `.ndp` package
+- `validate`: Validate an installed plugin or a `.ndp` package manifest
+- `enable`: Enable a plugin
+- `disable`: Disable a plugin
+- `edit`: Update a plugin's config and/or permissions
+- `rescan`: Re-discover plugins in the plugins folder
+
+`info` and `validate` accept either an installed plugin ID or a path to a `.ndp` package file (an argument ending in `.ndp` is treated as a file).
+
+Useful flags:
+
+- `list`: `-f, --format` (`table`, `csv`, or `json`; default `table`)
+- `info`: `-f, --format` (`text` or `json`; default `text`)
+- `edit` (provide at least one; paired flags are mutually exclusive):
+  - `--config` *(JSON string)* / `--config-file` *(path; use `-` to read from stdin)*
+  - `--users` *(comma-separated or JSON array of usernames)* / `--all-users`
+  - `--libraries` *(comma-separated or JSON array of integer library IDs)* / `--all-libraries`
+  - `--write-access` / `--no-write-access`
+
+Examples:
+
+```bash
+# List installed plugins as JSON
+navidrome plugin list -f json
+
+# Inspect a downloaded package before installing it
+navidrome plugin info ./my-plugin-1.2.0.ndp
+
+# Validate an installed plugin's manifest and config
+navidrome plugin validate my-plugin
+
+# Enable / disable a plugin
+navidrome plugin enable my-plugin
+navidrome plugin disable my-plugin
+
+# Set a plugin's configuration
+navidrome plugin edit my-plugin --config '{"apiKey":"abc123"}'
+
+# Read configuration from stdin
+cat config.json | navidrome plugin edit my-plugin --config-file -
+
+# Grant access to all users and allow write access
+navidrome plugin edit my-plugin --all-users --write-access
+
+# Re-discover plugins after copying a new .ndp into the plugins folder
+navidrome plugin rescan
+```
+
+{{% alert %}}
+These commands require the plugin system to be enabled (`Plugins.Enabled`, on by default), and `rescan` requires `Plugins.Folder` to be set. See [Plugins](/docs/usage/features/plugins/) for a full overview of the plugin system and web-UI management.
+{{% /alert %}}
 
 ## Notes and best practices
 

--- a/content/en/docs/usage/features/plugins/index.md
+++ b/content/en/docs/usage/features/plugins/index.md
@@ -55,6 +55,10 @@ Unless otherwise stated, plugins are **not** developed or maintained by the Navi
 
 5. **Configure the plugin**: Some plugins require additional configuration. Check the plugin's documentation for required settings.
 
+{{% alert %}}
+Prefer the command line? Rescanning, enabling, disabling, and configuring plugins can also be done from the CLI. See the [`plugin` command reference](/docs/usage/admin/cli/#plugin).
+{{% /alert %}}
+
 ## Server Configuration
 
 The following configuration options control the plugin system:


### PR DESCRIPTION
Documents the new `navidrome plugin` CLI command (from navidrome/navidrome#5682).

- Adds a `plugin` section to the CLI reference (`admin/cli.md`) covering all seven subcommands — `list`, `info`, `validate`, `enable`, `disable`, `edit`, `rescan` — with flags and examples, matching the page's existing per-command style.
- Updates the "Command overview" sentence to include `plugin`.
- Adds a short cross-link from the Plugins feature page's install steps to the new section.

Subcommand names, flags, and defaults were verified against `cmd/plugin.go`. Documentation-only; verified locally with a Hugo build and a browser pass (cross-link, `#plugin` anchor scroll, TOC entry).
