### PR TITLE
apps: refresh NaviBeat listing description and keywords

### DIFF
--- a/assets/apps/navibeat/index.yaml
+++ b/assets/apps/navibeat/index.yaml
@@ -8,7 +8,7 @@ platforms:
   tvos:
     store: https://apps.apple.com/app/navibeat/id6763518834
 api: OpenSubsonic
-description: "A native Apple-ecosystem player for Subsonic, OpenSubsonic, and Navidrome: iPhone, iPad, Mac, Apple TV, and Apple Watch all from one Universal Purchase. Time-synced lyrics, Mini Player on Mac with pin-on-top, full focus engine on Apple TV, offline downloads, gapless playback, and AirPlay throughout."
+description: "A native Apple-ecosystem player for Subsonic, OpenSubsonic, and Navidrome: iPhone, iPad, Mac, Apple TV, and Apple Watch (plus CarPlay) from one Universal Purchase. Time-synced lyrics, offline downloads, gapless playback, multi-library support, internet radio, Last.fm integration, a 10-band equalizer, and Listening Stats with a 24-hour listening clock and heatmaps. Fully localized into 10 languages with CarPlay voice search in every one of them, and a Mac add-on that syncs your library to Rockbox iPods, scrobbles included."
 screenshots:
   thumbnail: thumbnail.webp
   gallery:
@@ -24,3 +24,9 @@ keywords:
   - lyrics
   - universal-purchase
   - offline
+  - carplay
+  - equalizer
+  - statistics
+  - multi-library
+  - localized
+  - rockbox

--- a/assets/apps/navibeat/index.yaml
+++ b/assets/apps/navibeat/index.yaml
@@ -8,7 +8,7 @@ platforms:
   tvos:
     store: https://apps.apple.com/app/navibeat/id6763518834
 api: OpenSubsonic
-description: "A native Apple-ecosystem player for Subsonic, OpenSubsonic, and Navidrome: iPhone, iPad, Mac, Apple TV, and Apple Watch (plus CarPlay) from one Universal Purchase. Time-synced lyrics, offline downloads, gapless playback, multi-library support, internet radio, Last.fm integration, a 10-band equalizer, and Listening Stats with a 24-hour listening clock and heatmaps. Fully localized into 10 languages with CarPlay voice search in every one of them, and a Mac add-on that syncs your library to Rockbox iPods, scrobbles included."
+description: "A native Apple-ecosystem player for Subsonic, OpenSubsonic, and Navidrome: iPhone, iPad, Mac, Apple TV, Apple Watch, and CarPlay from one Universal Purchase. Time-synced lyrics, offline downloads, gapless playback, multi-library, internet radio, Last.fm, a 10-band equalizer, and Listening Stats. Fully localized into 10 languages with CarPlay voice search in all of them, plus a Mac add-on that syncs your library to Rockbox iPods, scrobbles included."
 screenshots:
   thumbnail: thumbnail.webp
   gallery:
@@ -20,13 +20,7 @@ screenshots:
 keywords:
   - swiftui
   - apple-tv
-  - mini-player
-  - lyrics
   - universal-purchase
-  - offline
   - carplay
   - equalizer
-  - statistics
-  - multi-library
-  - localized
   - rockbox


### PR DESCRIPTION
Hi! Refreshing the NaviBeat entry to reflect what shipped since the last update (2026-06-18):

- Fully localized into 10 languages (English, German, French, Spanish, Brazilian Portuguese, Russian, Ukrainian, Serbian, Simplified and Traditional Chinese)
- Listening Stats (24-hour listening clock, weekday heatmap, top artists/albums/songs)
- 10-band equalizer
- CarPlay voice search that works in every app language
- Multi-library support, internet radio, Last.fm integration (already shipped earlier, now mentioned)
- A macOS add-on that syncs the Navidrome library to Rockbox iPods (server-side transcoding, album art, playlists, scrobbles synced back)

Description stays within the same one-paragraph format as other entries; added matching keywords. Screenshots unchanged.

Thanks for maintaining the directory!