### PR TITLE
Add FreeBSD as supported platform option

### DIFF
--- a/assets/apps/_template/index.yaml
+++ b/assets/apps/_template/index.yaml
@@ -25,6 +25,7 @@ platforms:
   # Or just boolean for platforms without store links
   windows: true
   linux: true
+  freebsd: true
   # Web app with hosted URL
   web:
     url: https://my-awesome.netlify.app

--- a/assets/apps/app-schema.json
+++ b/assets/apps/app-schema.json
@@ -85,6 +85,7 @@
           ]
         },
         "linux": { "type": "boolean" },
+        "freebsd": { "type": "boolean" },
         "web": {
           "oneOf": [
             { "type": "boolean" },

--- a/assets/apps/firmium/index.yaml
+++ b/assets/apps/firmium/index.yaml
@@ -10,6 +10,7 @@ platforms:
   macos: false
   windows: true
   linux: true
+  freebsd: true
   web: false
   docker: false
   other: false

--- a/content/en/docs/developers/adding-apps.md
+++ b/content/en/docs/developers/adding-apps.md
@@ -91,6 +91,7 @@ The `isOpenSource` field controls whether the app displays an open source badge 
 - `macos` - macOS (optionally with Mac App Store link)
 - `windows` - Windows
 - `linux` - Linux
+- `freebsd` - FreeBSD
 - `web` - Web browser
 - `docker` - Docker container (optionally with Docker Hub link)
 - `other` - CLI tools, other platforms

--- a/layouts/apps/list.html
+++ b/layouts/apps/list.html
@@ -70,6 +70,10 @@
             <span><i class="fab fa-apple"></i> macOS</span>
           </label>
           <label class="filter-checkbox">
+            <input type="checkbox" name="platform" value="freebsd">
+            <span><i class="fab fa-freebsd"></i> FreeBSD</span>
+          </label>
+          <label class="filter-checkbox">
             <input type="checkbox" name="platform" value="web">
             <span><i class="fas fa-globe"></i> Web</span>
           </label>

--- a/layouts/partials/app-card.html
+++ b/layouts/partials/app-card.html
@@ -28,6 +28,7 @@
 {{ if $platforms.windows }}{{ $platformsList = $platformsList | append "windows" }}{{ end }}
 {{ if $platforms.linux }}{{ $platformsList = $platformsList | append "linux" }}{{ end }}
 {{ if $platforms.macos }}{{ $platformsList = $platformsList | append "macos" }}{{ end }}
+{{ if $platforms.freebsd }}{{ $platformsList = $platformsList | append "freebsd" }}{{ end }}
 {{ if $platforms.web }}{{ $platformsList = $platformsList | append "web" }}{{ end }}
 {{ if $platforms.docker }}{{ $platformsList = $platformsList | append "docker" }}{{ end }}
 {{ if $platforms.other }}{{ $platformsList = $platformsList | append "other" }}{{ end }}
@@ -165,6 +166,9 @@
         {{ end }}
         {{ if $platforms.linux }}
           <span title="Linux"><i class="fab fa-linux"></i></span>
+        {{ end }}
+        {{ if $platforms.freebsd }}
+          <span title="FreeBSD"><i class="fab fa-freebsd"></i></span>
         {{ end }}
         {{ if $platforms.web }}
           {{ if and (ne (printf "%T" $platforms.web) "bool") (isset $platforms.web "url") }}


### PR DESCRIPTION
## Summary
- Adds `freebsd` to the platforms JSON schema (was rejected as additional property)
- Adds FreeBSD filter checkbox to apps list page
- Adds FreeBSD icon to app cards
- Updates template and docs to list freebsd as a supported platform

## Test plan
- [x] `npm run validate:app` passes for an app with `freebsd: true`
- [x] Apps list page shows FreeBSD filter checkbox and filters correctly
- [x] App card shows FreeBSD icon when platform set