### PR TITLE
docs(smart-playlists): fix invalid top-level any+all example

### DIFF
--- a/content/en/docs/usage/features/smart-playlists/index.md
+++ b/content/en/docs/usage/features/smart-playlists/index.md
@@ -409,15 +409,19 @@ absolute or relative to your playlist. This allows your smart playlists to be tr
 { "inPlaylist": { "id": "../other_playlist.nsp" } }
 ```
 
-Here's an example of building a smart playlist out of multiple more focused playlists:
+Here's an example of building a smart playlist out of multiple more focused playlists. Keep all the rules under a
+single top-level group (`all` or `any`) and nest a group when you need to mix the two logics: a top-level `any` and
+`all` cannot be combined at the same level.
 
-```
+```json
 {
   "name": "Overplayed Favorites",
   "comment": "Most Played Favorites Played Within Last 4yr",
   "public": true,
-  "any": [{ "inPlaylist": { "path": "most-played-favorites.nsp" } }],
-  "all": [{ "notInPlaylist": { "path": "favorites-not-played-in-4-yrs.nsp" } }],
+  "all": [
+    { "inPlaylist": { "path": "most-played-favorites.nsp" } },
+    { "notInPlaylist": { "path": "favorites-not-played-in-4-yrs.nsp" } }
+  ],
   "sort": "playCount, lastPlayed"
 }
 ```


### PR DESCRIPTION
### Description

The "Overplayed Favorites" example in the Smart Playlists page combined a top-level `any` and a top-level `all` group. Navidrome doesn't support that: a smart playlist has a single top-level group, so the scanner kept only `any` and silently dropped `all`. This misled a user into filing navidrome/navidrome#5757.

This rewrites the example to use a single top-level `all` containing both rules, which preserves the intended meaning ("in one playlist **and** not in another"), and adds a short note that the two top-level groups can't be combined — nest one inside the other instead (as Example 2 already demonstrates). The fenced block is also tagged `json` for consistency with the other examples.

### Related Issues

Related to navidrome/navidrome#5757

The Navidrome server side is being fixed in navidrome/navidrome#5759, which makes such a file fail loudly during the scan instead of silently dropping rules.
