### PR TITLE
docs(audiomuse): fix client list and web UI Instant Mix instructions

### DIFF
--- a/content/en/docs/usage/integration/audiomuse/index.md
+++ b/content/en/docs/usage/integration/audiomuse/index.md
@@ -10,8 +10,8 @@ description: >
 
 It integrates with Navidrome through a [plugin](/docs/usage/features/plugins/), the [AudioMuse-AI-NV-plugin](https://github.com/NeptuneHub/AudioMuse-AI-NV-plugin). Once set up, you get:
 
-- **Instant Mix** in the Navidrome web UI: right-click any song and build a queue of sonically similar tracks
-- **Similar songs and similar artists** in Subsonic clients such as Symfonium, Feishin, Substreamer, Tempo, and Sonixd, through the standard `getSimilarSongs`/`getSimilarSongs2` (songs/radio) and `getArtistInfo`/`getArtistInfo2` (related artists) endpoints
+- **Instant Mix** in the Navidrome web UI: open any song's context menu and build a queue of sonically similar tracks
+- **Similar songs and similar artists** in Subsonic clients such as Symfonium, Feishin, Substreamer, Tempus, and Wavio, through the standard `getSimilarSongs`/`getSimilarSongs2` (songs/radio) and `getArtistInfo`/`getArtistInfo2` (related artists) endpoints
 - The [OpenSubsonic `sonicSimilarity` extension](#opensubsonic-sonicsimilarity-extension), which clients can use to fetch sonic matches and build song-to-song transitions
 
 {{< alert color="warning" title="Third-Party Project" >}}
@@ -88,7 +88,7 @@ On the AudioMuse-AI side, you should see API calls arriving each time you trigge
 
 ## Using it
 
-- **Web UI**: right-click a song (or open its context menu) and select **Instant Mix**. This requires `EnableExternalServices` to be on (the default).
+- **Web UI**: open a song's context menu (the three-dots button) and select **Instant Mix**. This requires `EnableExternalServices` to be on (the default).
 
 {{< imgproc instant-mix Fit "1200x1200" />}}
 - **Subsonic clients**: similar songs and artist radio work automatically through the standard `getSimilarSongs`/`getSimilarSongs2` endpoints, and related/similar artists through `getArtistInfo`/`getArtistInfo2` — all now answered by AudioMuse-AI's sonic analysis instead of external metadata services.


### PR DESCRIPTION
## Description

Fixes two inaccuracies on the new AudioMuse-AI integration page (#402):

- **Wrong client list**: the Subsonic client examples ("Symfonium, Feishin, Substreamer, Tempo, and Sonixd") came from AudioMuse-AI's stale `docs/NAVIDROME.md`. The authoritative "Front-End tested with the plugin" list in the [AudioMuse-AI-NV-plugin README](https://github.com/NeptuneHub/AudioMuse-AI-NV-plugin#audiomuse-ai-navidrome-plugin) names **Tempus** (a different app than Tempo) and **Wavio** — not Tempo and Sonixd.
- **No right-click in the web UI**: the "right-click a song" instructions were wrong; Instant Mix is reached through the song's three-dots context menu. Both mentions updated.

## Type of change

- [ ] App catalog entry (new app or update) — fill in the section below
- [x] Documentation
- [ ] Bug fix
- [ ] Styling / layout
- [ ] Other

## Checklist

- [ ] Internal links use Hugo's `relref` shortcode
- [ ] I previewed my changes locally (`npm start`) when relevant
- [x] The build passes (`npm run build`)
