### PR TITLE
Add shareable anchor links to configuration options

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -72,6 +72,13 @@
         }
       }
 
+      // Let long config names (e.g. DefaultPlaylistPublicVisibility) wrap so
+      // the trailing anchor icon stays in flow instead of being pushed offscreen.
+      &:nth-child(1) {
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
+
       &:nth-child(1)::before {
         content: "Config";
       }
@@ -94,6 +101,91 @@
       white-space: normal;
       overflow-wrap: anywhere;
       word-break: break-word;
+    }
+  }
+
+  // Per-option anchor links (added by js/config-anchors.js) for easy sharing.
+  tbody tr {
+    // Offset so the row isn't hidden under the sticky top navbar when linked to.
+    scroll-margin-top: 5rem;
+  }
+
+  .config-anchor {
+    display: inline-block;
+    margin-left: 0.35rem;
+    color: var(--bs-secondary-color);
+    text-decoration: none;
+    font-size: 0.85em;
+    line-height: 1;
+    position: relative;
+    opacity: 0.5;
+    transition: opacity 0.15s ease, color 0.15s ease;
+
+    &:hover,
+    &:focus {
+      color: var(--bs-primary);
+      opacity: 1;
+    }
+
+    // "Copied!" confirmation bubble shown briefly after clicking.
+    &.config-anchor--copied::after {
+      content: "Copied!";
+      position: absolute;
+      left: 50%;
+      bottom: calc(100% + 0.35rem);
+      transform: translateX(-50%);
+      padding: 0.2rem 0.4rem;
+      border-radius: 0.25rem;
+      background: var(--bs-emphasis-color, #333);
+      color: var(--bs-body-bg, #fff);
+      font-size: 0.7rem;
+      line-height: 1;
+      white-space: nowrap;
+      pointer-events: none;
+    }
+  }
+
+  // In the wide table layout on pointer devices, keep the icon hidden until the
+  // row is hovered. In the stacked layout (mobile) the icon stays visible so it
+  // is reachable without hover.
+  @media (min-width: 1200px) and (hover: hover) {
+    .config-anchor {
+      opacity: 0;
+    }
+
+    tbody tr:hover .config-anchor {
+      opacity: 0.6;
+
+      &:hover,
+      &:focus {
+        opacity: 1;
+      }
+    }
+  }
+
+  // Persistent glow on the option currently linked to via its anchor, so it
+  // stays easy to spot after the page finishes scrolling to it. Applied to the
+  // cells because browsers don't reliably paint backgrounds/shadows on
+  // `display: table-row` elements.
+  tbody tr.config-anchor-current td {
+    background-color: rgba(var(--bs-primary-rgb), 0.16);
+    box-shadow: inset 0 0 0.6rem rgba(var(--bs-primary-rgb), 0.4);
+    transition: background-color 0.35s ease, box-shadow 0.35s ease;
+  }
+
+  // In the stacked (mobile) layout each cell is a full-width block, so highlight
+  // the whole card once instead of every stacked cell.
+  @media (max-width: 1199.98px) {
+    tbody tr.config-anchor-current {
+      border-radius: 0.375rem;
+      background-color: rgba(var(--bs-primary-rgb), 0.16);
+      box-shadow: 0 0 0 0.12rem rgba(var(--bs-primary-rgb), 0.4);
+      transition: background-color 0.35s ease, box-shadow 0.35s ease;
+    }
+
+    tbody tr.config-anchor-current td {
+      background-color: transparent;
+      box-shadow: none;
     }
   }
 }

--- a/content/en/docs/usage/configuration/options.md
+++ b/content/en/docs/usage/configuration/options.md
@@ -7,6 +7,7 @@ description: >
   How to customize Navidrome to your environment
 aliases:
   - /docs/usage/configuration-options/
+config_anchors: true
 ---
 
 Navidrome allows some customization using environment variables, loading from a configuration file

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -10,3 +10,8 @@
     } catch (e) {}
   });
 </script>
+
+{{/* Per-option anchor links on the configuration options page */}}
+{{ if .Params.config_anchors }}
+<script src="{{ "js/config-anchors.js" | relURL }}"></script>
+{{ end }}

--- a/static/js/config-anchors.js
+++ b/static/js/config-anchors.js
@@ -51,29 +51,33 @@
       ta.style.opacity = '0';
       document.body.appendChild(ta);
       ta.select();
+      var ok = false;
       try {
-        document.execCommand('copy');
+        ok = document.execCommand('copy');
       } catch (e) {
-        /* clipboard not available */
+        ok = false;
       }
       document.body.removeChild(ta);
+      return ok;
     }
 
     function copy(text, link) {
-      var confirm = function () {
+      var confirmCopied = function () {
         link.classList.add('config-anchor--copied');
         setTimeout(function () {
           link.classList.remove('config-anchor--copied');
         }, 1500);
       };
+      // Only confirm when the copy actually succeeded, so we never claim
+      // "Copied!" if the clipboard write was blocked or unsupported.
       if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(text).then(confirm, function () {
-          fallbackCopy(text);
-          confirm();
+        navigator.clipboard.writeText(text).then(confirmCopied, function () {
+          if (fallbackCopy(text)) {
+            confirmCopied();
+          }
         });
-      } else {
-        fallbackCopy(text);
-        confirm();
+      } else if (fallbackCopy(text)) {
+        confirmCopied();
       }
     }
 
@@ -106,7 +110,7 @@
         link.className = 'config-anchor';
         link.href = '#' + id;
         link.title = 'Copy link to this option';
-        link.setAttribute('aria-label', 'Link to this option');
+        link.setAttribute('aria-label', 'Copy link to this option');
         link.innerHTML = '<i class="fas fa-link" aria-hidden="true"></i>';
 
         link.addEventListener('click', function (e) {

--- a/static/js/config-anchors.js
+++ b/static/js/config-anchors.js
@@ -1,0 +1,148 @@
+// Adds a small anchor link to every row of the configuration options tables,
+// so each option can be linked to and shared directly.
+(function () {
+  'use strict';
+
+  function slugify(text) {
+    return text
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  function ready(fn) {
+    if (document.readyState !== 'loading') {
+      fn();
+    } else {
+      document.addEventListener('DOMContentLoaded', fn);
+    }
+  }
+
+  ready(function () {
+    var containers = document.querySelectorAll('.config-options');
+    if (!containers.length) {
+      return;
+    }
+
+    var used = Object.create(null);
+    var currentRow = null;
+
+    // Keep a single option highlighted: the one currently linked to via the
+    // anchor. It stays lit until another option is visited, so it remains
+    // visible after the page finishes scrolling to it.
+    function setCurrent(row) {
+      if (currentRow === row) {
+        return;
+      }
+      if (currentRow) {
+        currentRow.classList.remove('config-anchor-current');
+      }
+      currentRow = row;
+      if (row) {
+        row.classList.add('config-anchor-current');
+      }
+    }
+
+    function fallbackCopy(text) {
+      var ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand('copy');
+      } catch (e) {
+        /* clipboard not available */
+      }
+      document.body.removeChild(ta);
+    }
+
+    function copy(text, link) {
+      var confirm = function () {
+        link.classList.add('config-anchor--copied');
+        setTimeout(function () {
+          link.classList.remove('config-anchor--copied');
+        }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(confirm, function () {
+          fallbackCopy(text);
+          confirm();
+        });
+      } else {
+        fallbackCopy(text);
+        confirm();
+      }
+    }
+
+    containers.forEach(function (container) {
+      var rows = container.querySelectorAll('table tbody tr');
+      Array.prototype.forEach.call(rows, function (row) {
+        var cells = row.querySelectorAll('td');
+        if (cells.length < 2) {
+          return;
+        }
+
+        // Prefer the config-file name; fall back to the env var (minus the ND_ prefix)
+        // for rows that only have an environment variable (config column shows "-").
+        var match = cells[0].textContent.trim().match(/^[A-Za-z0-9._]+/);
+        var base = match ? match[0] : cells[1].textContent.trim().replace(/^ND_/i, '');
+        if (!base) {
+          return;
+        }
+
+        var id = 'opt-' + slugify(base);
+        if (used[id]) {
+          used[id] += 1;
+          id = id + '-' + used[id];
+        } else {
+          used[id] = 1;
+        }
+        row.id = id;
+
+        var link = document.createElement('a');
+        link.className = 'config-anchor';
+        link.href = '#' + id;
+        link.title = 'Copy link to this option';
+        link.setAttribute('aria-label', 'Link to this option');
+        link.innerHTML = '<i class="fas fa-link" aria-hidden="true"></i>';
+
+        link.addEventListener('click', function (e) {
+          e.preventDefault();
+          var url =
+            window.location.origin + window.location.pathname + window.location.search + '#' + id;
+          if (window.location.hash === '#' + id) {
+            setCurrent(row);
+          } else {
+            window.location.hash = id;
+          }
+          copy(url, link);
+        });
+
+        cells[0].appendChild(document.createTextNode(' '));
+        cells[0].appendChild(link);
+      });
+    });
+
+    function scrollToHash() {
+      if (!window.location.hash) {
+        setCurrent(null);
+        return;
+      }
+      var el = document.getElementById(window.location.hash.slice(1));
+      if (el && el.matches('.config-options tbody tr')) {
+        el.scrollIntoView({ block: 'start' });
+        setCurrent(el);
+      } else {
+        setCurrent(null);
+      }
+    }
+
+    window.addEventListener('hashchange', scrollToHash);
+    // Handle a hash present on initial load (IDs are assigned above, after the
+    // browser's own anchor scroll has already run and found nothing).
+    scrollToHash();
+  });
+})();


### PR DESCRIPTION
## Summary

Each option in the [Configuration Options](https://www.navidrome.org/docs/usage/configuration/options/) tables now has a small link icon you can click to copy a shareable URL to that specific option — making it easy to point people at an exact setting.

## What it does

- **Per-option anchors:** every table row gets a stable id derived from its config name (e.g. `#opt-musicfolder`, `#opt-backup-path`), falling back to the env var name for rows whose config column is `-` (e.g. `#opt-configfile`).
- **Copy link:** clicking the icon copies the full option URL to the clipboard and shows a brief "Copied!" confirmation.
- **Persistent highlight:** opening an option's anchor scrolls to it (offset below the sticky navbar) and applies a persistent glow so it stays easy to spot after scrolling. Only one option is highlighted at a time; it moves as you visit others.
- **Responsive:** on desktop the icon reveals on row hover; in the stacked mobile layout it stays visible and long option names wrap so the icon isn't pushed offscreen. Desktop highlights the row cells; mobile highlights the whole option card.

## Implementation

- `static/js/config-anchors.js` — assigns ids, adds the copy-link icon, manages the persistent highlight.
- `assets/scss/_styles_project.scss` — icon, "Copied!" bubble, long-name wrapping, and glow styles (scoped to `.config-options`).
- `layouts/partials/hooks/body-end.html` — loads the script only on opted-in pages.
- `content/en/docs/usage/configuration/options.md` — `config_anchors: true` front matter enables it on just this page.

## Testing

Verified in a local Hugo build with browser automation: all 128 option rows get anchors with correct ids (including the env-var fallback), clicking copies the URL and shows the confirmation, and the highlight persists after scrolling and moves between options — confirmed in both desktop (table) and mobile (stacked) layouts.

## Notes

Anchors are derived from the config name, so renaming an option would break old links to it — same behavior as the site's existing heading anchors.