### PR TITLE
Update Cassette website and repo URLs

### DIFF
--- a/assets/apps/cassette/index.yaml
+++ b/assets/apps/cassette/index.yaml
@@ -5,10 +5,10 @@
 name: Cassette
 
 # Required: Official app website or homepage
-url: https://mathieudubart.github.io/cassette-web/
+url: https://getcassette.app
 
 # Optional: GitHub repository URL (displays an open source badge)
-repoUrl: https://github.com/mathieudubart/cassette
+repoUrl: https://github.com/CassetteLab/cassette
 
 # Required: At least one platform must be specified
 # Platforms can be boolean (true) or object with store URL


### PR DESCRIPTION
Point the app website at https://getcassette.app and move the repo link to the CassetteLab organization.

<!--
Thanks for contributing to the Navidrome website! 🎉
-->

## Description

<!-- What does this PR change, and why? -->

## Type of change

- [x] App catalog entry (new app or update) — fill in the section below
- [ ] Documentation
- [ ] Bug fix
- [ ] Styling / layout
- [ ] Other

## Checklist

- [ ] Internal links use Hugo's `relref` shortcode
- [ ] I previewed my changes locally (`npm start`) when relevant
- [ ] The build passes (`npm run build`)

<!-- ⬇️ Only fill in the section below if this PR adds or updates an app. Otherwise, delete it. -->

<details>
<summary>📱 Adding or updating an app in the catalog?</summary>

Guide: https://www.navidrome.org/docs/developers/adding-apps/

- [x] App supports the **OpenSubsonic**, **Subsonic**, or **Navidrome** API
- [x] Folder under `assets/apps/` uses **kebab-case** (e.g. `my-awesome-app`)
- [x] `index.yaml` has all required fields: `name`, `url`, `platforms`, `api`, `description`, `screenshots.thumbnail`
- [x] Thumbnail is a **real screenshot of the app** (not a logo or icon)
- [x] Images are **WebP**, max **1200px**, under **500KB** each (`npm run convert:images <app-name>`)
- [x] `npm run validate:app <app-name>` passes
- [x] I'm the app's author/maintainer, or have permission to submit it

</details>
