### PR TITLE
Update Nokkvi description and keywords

### DIFF
--- a/assets/apps/nokkvi/index.yaml
+++ b/assets/apps/nokkvi/index.yaml
@@ -4,7 +4,7 @@ repoUrl: https://github.com/f-o-o-g-s/nokkvi
 platforms:
   linux: true
 api: Navidrome
-description: "A native Rust/Iced desktop client for Navidrome with a PipeWire audio engine, GPU-accelerated visualizers, gapless playback, crossfade, and hot-reloadable theming and config. Linux-only; keyboard-first for tiling window managers, with full mouse support."
+description: "A native Navidrome client for Linux, built in Rust on its own PipeWire engine for gapless, opt-in bit-perfect playback, with a GPU-accelerated visualizer, in-app smart playlists, and shell control of the running player."
 screenshots:
   thumbnail: queue-scope.webp
   gallery:
@@ -16,8 +16,8 @@ screenshots:
 isFree: true
 keywords:
   - rust
-  - iced
   - pipewire
-  - visualizer
-  - keyboard-driven
-  - linux
+  - bit-perfect
+  - tiling-wm
+  - smart-playlists
+  - scriptable


### PR DESCRIPTION
Updates the Nokkvi catalog entry's description and search keywords.

The previous description predated several features. This refreshes it to reflect what Nokkvi does now — opt-in bit-perfect playback, in-app smart playlists, and shell control of the running player — and drops the "keyboard-first" framing since Nokkvi also has full mouse support. It stays within the length of comparable desktop-client entries (219 chars).

Keywords updated to higher-signal search terms: `bit-perfect`, `tiling-wm`, `smart-playlists`, `scriptable` (replacing `iced`, `visualizer`, `keyboard-driven`, `linux`).

Only `assets/apps/nokkvi/index.yaml` changes — screenshots are unchanged (already current from #383). `npm run validate:app nokkvi` passes with no errors or warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)