### PR TITLE
Update Narjo app isFree to false

### DIFF
--- a/assets/apps/narjo/index.yaml
+++ b/assets/apps/narjo/index.yaml
@@ -12,4 +12,4 @@ screenshots:
     - screen3.webp
     - screen4.webp
     - screen5.webp
-isFree: true
+isFree: false


### PR DESCRIPTION

<!--
Thanks for contributing to the Navidrome website! 🎉
-->

## Description
Narjo is not a free app. It's either a subscription-based app or a one-time purchase. It only free to download and includes 1-hour free trial of the full app.
<img width="414" height="896" alt="IMG_2338" src="https://github.com/user-attachments/assets/0f5afcb1-eae4-4166-bc6b-1c966fc4c916" />
<img width="414" height="896" alt="IMG_2344" src="https://github.com/user-attachments/assets/e3a96b97-bf0e-44f7-82a7-4fc75a2b8c24" />

<!-- What does this PR change, and why? -->

## Type of change

- [x] App catalog entry (new app or update) — fill in the section below
- [ ] Documentation
- [ ] Bug fix
- [ ] Styling / layout
- [ ] Other

## Checklist

- [ ] Internal links use Hugo's `relref` shortcode
- [ ] I previewed my changes locally (`npm start`) when relevant
- [ ] The build passes (`npm run build`)

