### PR TITLE
Fix log message for Jukebox mode troubleshooting

### DIFF
--- a/content/en/docs/usage/features/jukebox.md
+++ b/content/en/docs/usage/features/jukebox.md
@@ -161,7 +161,7 @@ Jukebox mode is currently not supported through the Navidrome Web UI.
 
 ## Troubleshooting
 
-If Jukebox mode is enabled one should see the message "**Starting playback server**" in the log. The number of detected audio devices and the device chosen will be given in the log as well:
+If Jukebox mode is enabled one should see the message "**Starting Jukebox service**" in the log. The number of detected audio devices and the device chosen will be given in the log as well:
 
 ```log
 INFO[0000] Starting playback server


### PR DESCRIPTION
Updated the troubleshooting section to reflect the correct log message for Jukebox mode.

<!--
Thanks for contributing to the Navidrome website! 🎉
-->

## Description

<!-- What does this PR change, and why? -->

## Type of change

- [ ] App catalog entry (new app or update) — fill in the section below
- [x] Documentation
- [ ] Bug fix
- [ ] Styling / layout
- [ ] Other

## Checklist

- [ ] Internal links use Hugo's `relref` shortcode
- [ ] I previewed my changes locally (`npm start`) when relevant
- [ ] The build passes (`npm run build`)

<!-- ⬇️ Only fill in the section below if this PR adds or updates an app. Otherwise, delete it. -->

<details>
<summary>📱 Adding or updating an app in the catalog?</summary>

Guide: https://www.navidrome.org/docs/developers/adding-apps/

- [ ] App supports the **OpenSubsonic**, **Subsonic**, or **Navidrome** API
- [ ] Folder under `assets/apps/` uses **kebab-case** (e.g. `my-awesome-app`)
- [ ] `index.yaml` has all required fields: `name`, `url`, `platforms`, `api`, `description`, `screenshots.thumbnail`
- [ ] Thumbnail is a **real screenshot of the app** (not a logo or icon)
- [ ] Images are **WebP**, max **1200px**, under **500KB** each (`npm run convert:images <app-name>`)
- [ ] `npm run validate:app <app-name>` passes
- [ ] I'm the app's author/maintainer, or have permission to submit it

</details>
