### PR TITLE
chore(apps): refresh NaviBeat entry for the 1.3.3 App Store release

### DIFF
--- a/assets/apps/navibeat/index.yaml
+++ b/assets/apps/navibeat/index.yaml
@@ -8,7 +8,7 @@ platforms:
   tvos:
     store: https://apps.apple.com/us/app/navibeat/id6763518834?platform=tv
 api: OpenSubsonic
-description: "A native Apple player for Subsonic, OpenSubsonic and Navidrome: iPhone, iPad, Mac, Apple TV, Apple Watch and CarPlay from one Universal Purchase. Time-synced lyrics, offline downloads, gapless playback, multi-library, internet radio, Last.fm and ListenBrainz, in 11 languages. No analytics, no accounts, no backend. A paid Mac add-on syncs your library to Rockbox players, scrobbles included."
+description: "A native Apple player for Subsonic, OpenSubsonic and Navidrome: iPhone, iPad, Mac, Apple TV, Apple Watch and CarPlay from one Universal Purchase. Time-synced lyrics, offline downloads, gapless playback, multi-library, internet radio, Last.fm and ListenBrainz, in 12 languages. Similar artists come from your own server, and AudioMuse-AI adds sonic similarity. Its own Navidrome plugin puts personal mixes on Home. No analytics, no accounts, no backend. A paid Mac add-on syncs to Rockbox players."
 screenshots:
   thumbnail: thumbnail.webp
   gallery:


### PR DESCRIPTION
Updates the description for `assets/apps/navibeat`. Nothing else in the entry changes: same screenshots, same keywords, same store links.

NaviBeat 1.3.3 went live on the App Store on 7 August and the entry still describes the version before it. Three things:

- the language count was 11 and is now 12 (Ukrainian, Polish, Serbian Latin and both Chinese scripts among them),
- similar artists can now be resolved by the user's own server, with AudioMuse-AI upgrading that to sonic similarity, which seemed worth naming in a Navidrome directory specifically,
- NaviBeat ships a Navidrome server plugin that puts personal mixes on the Home screen.

Description is 496 characters, within the 500 limit, and `npm run validate:app navibeat` passes.