### PR TITLE
docs: add macOS permissions and protected folder access (#423)

### DIFF
--- a/content/en/docs/installation/macos.md
+++ b/content/en/docs/installation/macos.md
@@ -45,6 +45,112 @@ The example shown assumes a few things:
 </plist>
 ```
 
+## File ownership and permissions
+
+A `LaunchAgent` runs as your own user, not as `root`. All files must therefore belong to
+your user. If you created `/opt/navidrome` with `sudo`, the folder belongs to `root` and
+Navidrome cannot write to it.
+
+Set the owner and the permissions like this:
+
+```bash
+# Give the whole folder to your user
+sudo chown -R "$(whoami):staff" /opt/navidrome
+
+# Make the binary executable
+chmod 755 /opt/navidrome/navidrome
+
+# Restrict the config file, as it can contain secrets
+chmod 600 /opt/navidrome/navidrome.toml
+
+# Let Navidrome write the database and the log
+chmod 755 /opt/navidrome/data
+chmod 644 /opt/navidrome/navidrome.log
+
+# launchd refuses a plist that other users can write
+chmod 644 ~/Library/LaunchAgents/navidrome.plist
+```
+
+This table shows the required values:
+
+| Path | Owner | Mode | Notes |
+|------|-------|------|-------|
+| `/opt/navidrome` | your user | `755` | Working directory |
+| `/opt/navidrome/navidrome` | your user | `755` | Must be executable |
+| `/opt/navidrome/navidrome.toml` | your user | `600` | Read only for you |
+| `/opt/navidrome/data` | your user | `755` | `DataFolder`, must be writable |
+| `/opt/navidrome/navidrome.log` | your user | `644` | Must be writable |
+| `~/Library/LaunchAgents/navidrome.plist` | your user | `644` | `launchd` rejects mode `666` |
+| Your music folder | any | — | Read access is sufficient |
+
+## Access to protected folders
+
+Correct file permissions are not always sufficient. macOS has a second, independent privacy
+system. It blocks some folders even when the file permissions permit access. A service started
+by `launchd` gets no permissions from your terminal, so this problem is common.
+
+These folders are blocked:
+
+- `~/Desktop`, `~/Documents` and `~/Downloads`
+- `~/Music/Music`, the Apple Music library folder
+- All external and network volumes in `/Volumes`
+
+These folders are not blocked:
+
+- `~/Music` itself, but not the `Music` subfolder in it
+- `/Users/Shared`
+- `/opt` and other folders outside your home folder
+
+**The simplest solution is to keep your music in a folder that macOS does not block**, for
+example `/Users/Shared/Music`. Then you do not need any of the steps below.
+
+### Symptoms
+
+When macOS blocks your music folder, Navidrome does not report a clear error. Look for these
+signs instead:
+
+- The library is empty after a scan, and no track is found.
+- The log contains this line, which gives the wrong reason:
+
+  ```
+  level=warning msg="Scanner: Target folder does not exist." error="open .: operation not permitted"
+  ```
+
+  The folder does exist. The permission is the real cause.
+
+There is a third symptom that is easy to miss. The first time Navidrome reads a blocked folder,
+macOS shows a permission dialog, and Navidrome **waits** for your answer. If you do not see the
+dialog, the scan seems to freeze, and the log shows:
+
+```
+level=error msg="Scan failed" error="library count: context canceled"
+```
+
+### How to give access
+
+Two methods are possible. Both work.
+
+1. **Answer the dialog.** Click **Allow** when the dialog appears. macOS then adds an entry
+   under **System Settings** > **Privacy & Security** > **Files & Folders**. You can switch it
+   on and off there later.
+2. **Give Full Disk Access.** Use this method if you did not see the dialog, or if you closed
+   it:
+   - Open **System Settings** > **Privacy & Security** > **Full Disk Access**.
+   - Click **+**, then press <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>G</kbd> and enter
+     `/opt/navidrome`.
+   - Select the `navidrome` binary and set the switch to on.
+   - Restart the service.
+
+{{% alert title="You must do this again after each update" color="warning" %}}
+macOS attaches the permission to the binary itself, not to its path. When you install a new
+version of Navidrome, the permission no longer applies.
+
+After an update, Navidrome cannot read your music folder, and macOS shows the dialog again. If
+nobody answers that dialog, the scan waits and then fails with `context canceled`.
+
+Keep your music in a folder that macOS does not block to prevent this.
+{{% /alert %}}
+
 Then to load the service, run:
 ```bash
 launchctl load ~/Library/LaunchAgents/navidrome.plist

--- a/content/en/docs/installation/macos.md
+++ b/content/en/docs/installation/macos.md
@@ -63,8 +63,12 @@ chmod 755 /opt/navidrome/navidrome
 # Restrict the config file, as it can contain secrets
 chmod 600 /opt/navidrome/navidrome.toml
 
-# Let Navidrome write the database and the log
-chmod 755 /opt/navidrome/data
+# Create the data folder and keep it private.
+# Use the path that you set in the DataFolder option.
+mkdir -p /opt/navidrome/data
+chmod 700 /opt/navidrome/data
+
+# Let Navidrome write the log
 chmod 644 /opt/navidrome/navidrome.log
 
 # launchd refuses a plist that other users can write
@@ -78,10 +82,22 @@ This table shows the required values:
 | `/opt/navidrome` | your user | `755` | Working directory |
 | `/opt/navidrome/navidrome` | your user | `755` | Must be executable |
 | `/opt/navidrome/navidrome.toml` | your user | `600` | Read only for you |
-| `/opt/navidrome/data` | your user | `755` | `DataFolder`, must be writable |
+| `/opt/navidrome/data` | your user | `700` | `DataFolder`, see the warning below |
 | `/opt/navidrome/navidrome.log` | your user | `644` | Must be writable |
 | `~/Library/LaunchAgents/navidrome.plist` | your user | `644` | `launchd` rejects mode `666` |
 | Your music folder | any | — | Read access is sufficient |
+
+{{% alert title="Keep the data folder private" color="warning" %}}
+The `DataFolder` option sets where the data folder is. If you did not use
+`/opt/navidrome/data`, apply the commands above to your own path.
+
+Navidrome makes this folder on the first start if it does not exist. It makes the folder and
+the database file readable for all users. The database holds the accounts and the passwords of
+your users. Thus, on a Mac with more than one account, a different user can read them.
+
+Set the mode of the data folder to `700` to prevent this. Navidrome operates correctly with
+this mode. If Navidrome already made the folder, set the mode again after the first start.
+{{% /alert %}}
 
 ## Access to protected folders
 

--- a/content/en/docs/installation/macos.md
+++ b/content/en/docs/installation/macos.md
@@ -68,8 +68,9 @@ chmod 600 /opt/navidrome/navidrome.toml
 mkdir -p /opt/navidrome/data
 chmod 700 /opt/navidrome/data
 
-# Let Navidrome write the log
-chmod 644 /opt/navidrome/navidrome.log
+# Create the log file and keep it private
+touch /opt/navidrome/navidrome.log
+chmod 600 /opt/navidrome/navidrome.log
 
 # launchd refuses a plist that other users can write
 chmod 644 ~/Library/LaunchAgents/navidrome.plist
@@ -83,7 +84,7 @@ This table shows the required values:
 | `/opt/navidrome/navidrome` | your user | `755` | Must be executable |
 | `/opt/navidrome/navidrome.toml` | your user | `600` | Read only for you |
 | `/opt/navidrome/data` | your user | `700` | `DataFolder`, see the warning below |
-| `/opt/navidrome/navidrome.log` | your user | `644` | Must be writable |
+| `/opt/navidrome/navidrome.log` | your user | `600` | See the warning below |
 | `~/Library/LaunchAgents/navidrome.plist` | your user | `644` | `launchd` rejects mode `666` |
 | Your music folder | any | — | Read access is sufficient |
 
@@ -97,6 +98,16 @@ your users. Thus, on a Mac with more than one account, a different user can read
 
 Set the mode of the data folder to `700` to prevent this. Navidrome operates correctly with
 this mode. If Navidrome already made the folder, set the mode again after the first start.
+{{% /alert %}}
+
+{{% alert title="Keep the log file private" color="warning" %}}
+The log can contain secrets. If you set `LogLevel` to `debug`, Navidrome writes the full
+configuration to the log at each start. Some values are shown as `[REDACTED]`, but not all of
+them. For example, the Last.fm `ApiKey` and `Secret` are written in plain text.
+
+`launchd` makes the log file readable for all users if the file does not exist. Thus, make the
+file yourself before you start the service, and set the mode to `600`. `launchd` keeps this
+mode and continues to write to the file.
 {{% /alert %}}
 
 ## Access to protected folders


### PR DESCRIPTION
Closes #423

The macOS install page never explained which owners and modes the files need. It also said nothing about the macOS privacy system, which is the more common reason a library comes up empty.

## What this adds

- **File ownership and permissions** — a copy-paste block plus a table of the required owner and mode for each path.
- **Access to protected folders** — which folders macOS blocks, how to recognise the problem, and the two ways to fix it.

## Verified, not assumed

Every claim was tested on macOS 26.6.1 with Navidrome v0.63.2 running as a real LaunchAgent, using a single test track and a fresh DB per run.

| Test | Setup | Tracks found |
|---|---|---|
| A | Music in `/Users/Shared` | 1 |
| B | Music in `~/Documents`, Files & Folders grant ON | 1 |
| C | Music in `~/Documents`, all grants OFF | **0** |
| D | Music in `~/Documents`, Full Disk Access ON | 1 |
| F | Same as D, but binary swapped to v0.62.0 | **0** |

Findings that changed the text:

- `launchd` rejects a plist with mode `666` (`Load failed: 5`), but accepts `664` and `644`.
- `~/Music` is **not** blocked. `~/Music/Music`, the Apple Music library folder, is. So are `~/Desktop`, `~/Documents`, `~/Downloads` and everything under `/Volumes`.
- When blocked, Navidrome does not log a permission error. It logs `Scanner: Target folder does not exist.` with `error="open .: operation not permitted"`, which sends people off to check their path.
- On first access Navidrome **waits** for the macOS dialog. If nobody answers it, the scan hangs and then fails with `Scan failed: library count: context canceled`.
- The grant is bound to the binary, not to its path. Test F swapped v0.63.2 for v0.62.0 at the same path with the grant still in place, and the library went from 1 track to 0. **Every Navidrome update silently breaks a blocked music folder.** This is called out in an alert box.

Because of that last point the page now leads with the advice to keep music somewhere macOS does not block, such as `/Users/Shared/Music`, which avoids the whole problem.

`hugo` builds clean.