### PR TITLE
docs(docker): explain data folder permissions and the DB startup crash

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -126,6 +126,13 @@ Ensure the `user` directive matches the owner of your music folder:
 ```yaml
 user: 1000:1000  # Should match: ls -n /path/to/music
 ```
+
+The same user also needs **write** access to the data folder. If it does not have it, Navidrome cannot
+create its database and stops with `unable to open database file: no such file or directory`. Fix it with:
+```bash
+sudo chown -R 1000:1000 /path/to/data
+```
+See [Docker permissions](/docs/installation/docker/#permissions) for details.
 {{% /tab %}}
 {{% tab header="Linux" %}}
 ```bash

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -130,7 +130,7 @@ user: 1000:1000  # Should match: ls -n /path/to/music
 The same user also needs **write** access to the data folder. If it does not have it, Navidrome cannot
 create its database and stops with `unable to open database file: no such file or directory`. Fix it with:
 ```bash
-sudo chown -R 1000:1000 /path/to/data
+sudo chown -R $(id -u):$(id -g) /path/to/data  # must match the `user` directive
 ```
 See [Docker permissions](/docs/installation/docker/#permissions) for details.
 {{% /tab %}}

--- a/content/en/docs/installation/docker.md
+++ b/content/en/docs/installation/docker.md
@@ -58,8 +58,11 @@ Navidrome needs:
 - read **and write** access to `/data`, where it creates its database and cache
 - read access to `/music`
 
-Both must be granted to the `UID:GID` you put in the `user` directive. The two folders fail in different
-ways, so the logs tell you which one is wrong.
+Both must be granted to the `UID:GID` you put in the `user` directive. Run `id -u` and `id -g` to see the
+IDs of your own account, and `ls -n /path/to/your/music/folder` to see which IDs own your music. Whatever
+numbers you pick, use the same ones in the `user` directive and in the commands below.
+
+The two folders fail in different ways, so the logs tell you which one is wrong.
 
 #### The data folder is not writable
 
@@ -74,7 +77,7 @@ Create the data folder and give it to the same user you run the container as:
 
 ```shell
 mkdir -p /path/to/data
-sudo chown -R 1000:1000 /path/to/data
+sudo chown -R $(id -u):$(id -g) /path/to/data
 ```
 
 #### The music folder is not readable
@@ -90,7 +93,7 @@ The folder does exist, despite what the second message says. The container user 
 Give that user read and execute access, either by changing the owner:
 
 ```shell
-sudo chown -R 1000:1000 /path/to/your/music/folder
+sudo chown -R $(id -u):$(id -g) /path/to/your/music/folder
 ```
 
 or, if other programs also use the folder, by opening it for reading:
@@ -98,9 +101,6 @@ or, if other programs also use the folder, by opening it for reading:
 ```shell
 sudo chmod -R a+rX /path/to/your/music/folder
 ```
-
-Use `id -u` and `id -g` to find the IDs of your own user, and `ls -n /path/to/your/music/folder` to see
-which IDs own your music.
 
 Two things people often try that do not work:
 

--- a/content/en/docs/installation/docker.md
+++ b/content/en/docs/installation/docker.md
@@ -19,7 +19,7 @@ below to your existing file):
 services:
   navidrome:
     image: deluan/navidrome:latest
-    user: 1000:1000 # should be owner of volumes
+    user: 1000:1000 # must own the data folder - run `id -u` and `id -g`. See Permissions below
     ports:
       - "4533:4533"
     restart: unless-stopped
@@ -48,9 +48,44 @@ $ docker run -d \
    deluan/navidrome:latest
 ```
 
+### Permissions
+
+The configurations above are examples. The IDs in them will not always match your machine, so adjust
+them before you start the container.
+
+Navidrome needs:
+
+- read **and write** access to `/data`, where it creates its database and cache
+- read access to `/music`
+
+Both must be granted to the `UID:GID` you put in the `user` directive. If the data folder is not writable
+by that user, Navidrome cannot create the database and stops at startup with:
+
+```
+level=error msg="Error applying PRAGMA optimize" error="unable to open database file: no such file or directory"
+panic: runtime error: invalid memory address or nil pointer dereference
+```
+
+To fix it, create the data folder and give it to the same user you run the container as:
+
+```shell
+mkdir -p /path/to/data
+sudo chown -R 1000:1000 /path/to/data
+```
+
+Use `id -u` and `id -g` to find the IDs of your own user, and `ls -n /path/to/your/music/folder` to see
+which IDs own your music.
+
+Two things people often try that do not work:
+
+- **`PUID` and `PGID` have no effect.** Those variables are a [linuxserver.io](https://docs.linuxserver.io/general/understanding-puid-and-pgid/)
+  convention. Navidrome's image ignores them. Use the `user` directive instead.
+- **Removing the `user` directive is not a fix.** The container then runs as `root`, which can write
+  anywhere, so the error goes away. Do not do this in production. Fix the folder ownership instead.
+
 ### Customization
 
-- The `user` argument should ideally reflect the `UID:GID` of the owner of the music library to avoid permission issues. For testing purpose you could omit this directive, but as a rule of thumb you should not run a production container as `root`.
+- The `user` argument should reflect the `UID:GID` that owns the data folder and can read the music library. See [Permissions](#permissions) above.
 - Remember to change the `volumes` paths to point to your local paths. `/data` is where Navidrome
   will store its DB and cache, `/music` is where your music files are stored. For [multi-library setups](/docs/usage/features/multi-library/), you may need to mount additional volumes for each library.
 - [Configuration options](/docs/usage/configuration/options/) can be customized with environment

--- a/content/en/docs/installation/docker.md
+++ b/content/en/docs/installation/docker.md
@@ -19,7 +19,7 @@ below to your existing file):
 services:
   navidrome:
     image: deluan/navidrome:latest
-    user: 1000:1000 # must own the data folder - run `id -u` and `id -g`. See Permissions below
+    user: 1000:1000 # must own the data folder and be able to read music folder(s). See Permissions below
     ports:
       - "4533:4533"
     restart: unless-stopped
@@ -58,19 +58,45 @@ Navidrome needs:
 - read **and write** access to `/data`, where it creates its database and cache
 - read access to `/music`
 
-Both must be granted to the `UID:GID` you put in the `user` directive. If the data folder is not writable
-by that user, Navidrome cannot create the database and stops at startup with:
+Both must be granted to the `UID:GID` you put in the `user` directive. The two folders fail in different
+ways, so the logs tell you which one is wrong.
+
+#### The data folder is not writable
+
+Navidrome cannot create its database, and the container stops at startup:
 
 ```
 level=error msg="Error applying PRAGMA optimize" error="unable to open database file: no such file or directory"
 panic: runtime error: invalid memory address or nil pointer dereference
 ```
 
-To fix it, create the data folder and give it to the same user you run the container as:
+Create the data folder and give it to the same user you run the container as:
 
 ```shell
 mkdir -p /path/to/data
 sudo chown -R 1000:1000 /path/to/data
+```
+
+#### The music folder is not readable
+
+Navidrome starts and the web interface works, but your library stays empty. The logs show:
+
+```
+level=error msg="Error starting watcher" error="open /music: permission denied" lib=/music/...
+level=warning msg="Scanner: Target folder does not exist." error="open .: permission denied" path=.
+```
+
+The folder does exist, despite what the second message says. The container user just cannot open it.
+Give that user read and execute access, either by changing the owner:
+
+```shell
+sudo chown -R 1000:1000 /path/to/your/music/folder
+```
+
+or, if other programs also use the folder, by opening it for reading:
+
+```shell
+sudo chmod -R a+rX /path/to/your/music/folder
 ```
 
 Use `id -u` and `id -g` to find the IDs of your own user, and `ls -n /path/to/your/music/folder` to see
@@ -81,7 +107,7 @@ Two things people often try that do not work:
 - **`PUID` and `PGID` have no effect.** Those variables are a [linuxserver.io](https://docs.linuxserver.io/general/understanding-puid-and-pgid/)
   convention. Navidrome's image ignores them. Use the `user` directive instead.
 - **Removing the `user` directive is not a fix.** The container then runs as `root`, which can write
-  anywhere, so the error goes away. Do not do this in production. Fix the folder ownership instead.
+  anywhere, so the error goes away. **Do not do this in production.** Fix the folder ownership instead.
 
 ### Customization
 


### PR DESCRIPTION
## Description

Follow-up to navidrome/navidrome#5261, which was closed with the conclusion that the data folder must be owned by the UID in the `user` directive.

The Docker page's compose example hardcodes `user: 1000:1000` and only mentions the *music* folder. When that UID cannot write to `/data`, Navidrome fails to create its database and panics:

```
level=error msg="Error applying PRAGMA optimize" error="unable to open database file: no such file or directory"
panic: runtime error: invalid memory address or nil pointer dereference
```

That string was nowhere on navidrome.org, so people searching it found only the issue tracker.

This PR adds a `### Permissions` section to `installation/docker.md`:

- `/data` needs read **and write** for the `UID:GID` in `user`; `/music` needs read
- the exact error text, so search engines land people on this page
- the fix: `mkdir -p /path/to/data && sudo chown -R 1000:1000 /path/to/data`
- `PUID`/`PGID` have no effect (linuxserver.io convention, not this image)
- removing `user` runs the container as root, which is not a fix

Also updates the inline comment in the compose example, the `user` bullet under Customization, and the Docker tab of the Getting Started "Permission Problems" section.

Podman is intentionally left out, as #417 covers it.

## Type of change

- [ ] App catalog entry (new app or update)
- [x] Documentation
- [ ] Bug fix
- [ ] Styling / layout
- [ ] Other

## Checklist

- [x] Internal links use Hugo's `relref` shortcode <!-- N/A: no docs page uses relref; matched existing plain-link style -->
- [x] I previewed my changes locally
- [x] The build passes