### PR TITLE
feat(apps): add pricing field with in-app purchase and free trial badges

### DIFF
--- a/.claude/skills/app-entry-creator/SKILL.md
+++ b/.claude/skills/app-entry-creator/SKILL.md
@@ -136,11 +136,11 @@ Map discovered information to platforms:
    - `api`: One of `OpenSubsonic`, `Subsonic`, `Navidrome`
    - `description`: 1-2 sentences (max 500 chars)
    - `screenshots.thumbnail`: Filename of downloaded thumbnail
+   - `pricing`: `free`, `freemium` (free + in-app purchases), `trial` (paid + free trial), or `paid`
 
 4. **Optional fields** (include if found):
    - `repoUrl`: Repository URL (for release date tracking)
    - `isOpenSource`: Set to `false` if repo exists but source is not public (see Step 3)
-   - `isFree`: Set to `true` if app is free
    - `screenshots.gallery`: Array of screenshot filenames (max 5)
    - `keywords`: Search terms not in name/description (max 6)
 

--- a/.github/skills/app-entry-creator/SKILL.md
+++ b/.github/skills/app-entry-creator/SKILL.md
@@ -142,11 +142,11 @@ Map discovered information to platforms:
    - `api`: One of `OpenSubsonic`, `Subsonic`, `Navidrome`
    - `description`: 1-2 sentences (max 500 chars)
    - `screenshots.thumbnail`: Filename of downloaded thumbnail
+   - `pricing`: `free`, `freemium` (free + in-app purchases), `trial` (paid + free trial), or `paid`
 
 4. **Optional fields** (include if found):
    - `repoUrl`: Repository URL (for release date tracking)
    - `isOpenSource`: Set to `false` if repo exists but source is not public (see Step 3)
-   - `isFree`: Set to `true` if app is free
    - `screenshots.gallery`: Array of screenshot filenames (max 5)
    - `keywords`: Search terms not in name/description (max 6)
 

--- a/assets/apps/_template/index.yaml
+++ b/assets/apps/_template/index.yaml
@@ -53,8 +53,12 @@ screenshots:
     - screen2.webp
     - screen3.webp
 
-# Optional: Set to true if the app is free (no purchase required)
-isFree: true
+# Required: Pricing model. One of:
+#   free     - no cost at all
+#   freemium - free to download, has in-app purchases / subscriptions
+#   trial    - purchase required, but a free trial is available
+#   paid     - purchase required
+pricing: free
 
 # Optional: Additional search terms (max 6, not displayed on app card)
 # Use for alternative names, abbreviations, or key features

--- a/assets/apps/airdrome/index.yaml
+++ b/assets/apps/airdrome/index.yaml
@@ -15,7 +15,7 @@ screenshots:
     - screen1.webp
     - screen2.webp
 repoUrl: https://github.com/JPGuillemin/Airdrome
-isFree: true
+pricing: free
 keywords:
   - web
   - self-hosted

--- a/assets/apps/airsonic-refix/index.yaml
+++ b/assets/apps/airsonic-refix/index.yaml
@@ -12,3 +12,5 @@ screenshots:
   gallery:
     - screen1.webp
 repoUrl: https://github.com/tamland/airsonic-refix
+
+pricing: free

--- a/assets/apps/amcfy/index.yaml
+++ b/assets/apps/amcfy/index.yaml
@@ -16,7 +16,7 @@ screenshots:
     - screen3.webp
     - screen4.webp
     - screen5.webp
-isFree: true
+pricing: free
 keywords:
   - offline
   - equalizer

--- a/assets/apps/ampcast/index.yaml
+++ b/assets/apps/ampcast/index.yaml
@@ -13,3 +13,5 @@ description: "Browse/playback from Navidrome, Spotify, Apple Music, YouTube and 
 screenshots:
   thumbnail: thumbnail.webp
 repoUrl: https://github.com/rekkyrosso/ampcast
+
+pricing: free

--- a/assets/apps/amperfy/index.yaml
+++ b/assets/apps/amperfy/index.yaml
@@ -13,3 +13,5 @@ screenshots:
     - screen2.webp
     - screen3.webp
 repoUrl: https://github.com/BLeeEZ/amperfy
+
+pricing: free

--- a/assets/apps/aonsoku/index.yaml
+++ b/assets/apps/aonsoku/index.yaml
@@ -17,3 +17,5 @@ screenshots:
     - screen2.webp
     - screen3.webp
 repoUrl: https://github.com/victoralvesf/aonsoku
+
+pricing: free

--- a/assets/apps/app-schema.json
+++ b/assets/apps/app-schema.json
@@ -3,7 +3,7 @@
   "title": "Navidrome Client App",
   "description": "Schema for Navidrome client app metadata",
   "type": "object",
-  "required": ["name", "url", "platforms", "api", "description", "screenshots"],
+  "required": ["name", "url", "platforms", "api", "description", "screenshots", "pricing"],
   "properties": {
     "name": {
       "type": "string",
@@ -166,9 +166,10 @@
       "type": "boolean",
       "description": "Whether the app source code is publicly available under an open source license. If repoUrl is set and isOpenSource is omitted, defaults to true."
     },
-    "isFree": {
-      "type": "boolean",
-      "description": "Whether the app is free (no purchase required)"
+    "pricing": {
+      "type": "string",
+      "enum": ["free", "freemium", "trial", "paid"],
+      "description": "Pricing model: 'free' (no cost), 'freemium' (free with in-app purchases), 'trial' (paid with a free trial), 'paid' (purchase required)."
     },
     "keywords": {
       "type": "array",

--- a/assets/apps/arpeggi/index.yaml
+++ b/assets/apps/arpeggi/index.yaml
@@ -2,7 +2,7 @@ name: Arpeggi
 url: https://www.reddit.com/r/arpeggiApp/
 repoUrl: https://github.com/argie-w/Arpeggi-App
 isOpenSource: false
-isFree: true
+pricing: free
 platforms:
   ios:
     store: https://apps.apple.com/us/app/arpeggi/id6503619183

--- a/assets/apps/aura/index.yaml
+++ b/assets/apps/aura/index.yaml
@@ -11,7 +11,7 @@ api: Subsonic
 
 description: "A blazingly fast, lightweight desktop music player for Navidrome and Subsonic-compatible servers. Native Rust audio engine, instant full-text search, OS media controls, and a tiny memory footprint."
 
-isFree: true
+pricing: free
 
 screenshots:
   thumbnail: thumbnail.webp

--- a/assets/apps/aurial/index.yaml
+++ b/assets/apps/aurial/index.yaml
@@ -11,3 +11,5 @@ screenshots:
     - screen2.webp
     - screen3.webp
 repoUrl: https://github.com/shrimpza/aurial
+
+pricing: free

--- a/assets/apps/bonob/index.yaml
+++ b/assets/apps/bonob/index.yaml
@@ -16,3 +16,5 @@ screenshots:
   thumbnail: thumbnail.webp
   gallery:
     - screen1.webp
+
+pricing: free

--- a/assets/apps/cadence/index.yaml
+++ b/assets/apps/cadence/index.yaml
@@ -6,7 +6,7 @@ platforms:
   macos:
     store: https://apps.apple.com/us/app/cadence-for-navidrome/id6748622506?mt=12
 api: Subsonic
-isFree: true
+pricing: paid
 description: "A minimal iOS/macOS client with CarPlay integration, Spotlight search support and a focus on queuing artists, albums and playlists."
 screenshots:
   thumbnail: thumbnail.webp

--- a/assets/apps/cassette/index.yaml
+++ b/assets/apps/cassette/index.yaml
@@ -38,8 +38,7 @@ screenshots:
     - macOS_2.webp
     - macOS.webp
 
-# Optional: Set to true if the app is free (no purchase required)
-isFree: true
+pricing: free
 
 # Optional: Additional search terms (max 6, not displayed on app card)
 # Use for alternative names, abbreviations, or key features

--- a/assets/apps/castafiore/index.yaml
+++ b/assets/apps/castafiore/index.yaml
@@ -14,3 +14,5 @@ screenshots:
     - screen2.webp
     - screen3.webp
 repoUrl: https://github.com/sawyerf/Castafiore
+
+pricing: free

--- a/assets/apps/chora/index.yaml
+++ b/assets/apps/chora/index.yaml
@@ -12,3 +12,5 @@ screenshots:
     - screen2.webp
     - screen3.webp
 repoUrl: https://github.com/CraftWorksMC/Chora
+
+pricing: free

--- a/assets/apps/darktone/index.yaml
+++ b/assets/apps/darktone/index.yaml
@@ -10,7 +10,7 @@ screenshots:
     - explore.webp
     - artist.webp
     - lockscreen.webp
-isFree: true
+pricing: free
 keywords:
   - navidrome
   - music

--- a/assets/apps/dsub/index.yaml
+++ b/assets/apps/dsub/index.yaml
@@ -14,3 +14,5 @@ keywords:
   - offline
   - chromecast
   - android auto
+
+pricing: free

--- a/assets/apps/dsub2000/index.yaml
+++ b/assets/apps/dsub2000/index.yaml
@@ -16,3 +16,5 @@ keywords:
   - offline
   - chromecast
   - android auto
+
+pricing: free

--- a/assets/apps/echospace/index.yaml
+++ b/assets/apps/echospace/index.yaml
@@ -23,3 +23,5 @@ keywords:
   - webdav
   - nas
   - carplay
+
+pricing: freemium

--- a/assets/apps/eko/index.yaml
+++ b/assets/apps/eko/index.yaml
@@ -5,7 +5,7 @@ platforms:
   macos: true
 api: OpenSubsonic
 description: "A bit-perfect audiophile player for macOS. A native Rust engine matches the output device to each file's sample rate (no OS resampling), with an honest SOURCE → OUTPUT signal-path display and a true bit-perfect seal — plus a 10-band graphic EQ, ReplayGain, gapless playback, a live FFT spectrum, lyrics, scrobbling, a sleep timer and media keys, in a neumorphic light/dark interface."
-isFree: true
+pricing: free
 screenshots:
   thumbnail: thumbnail.webp
   gallery:

--- a/assets/apps/feishin/index.yaml
+++ b/assets/apps/feishin/index.yaml
@@ -17,3 +17,5 @@ screenshots:
     - screen3.webp
     - screen4.webp
 repoUrl: https://github.com/jeffvli/feishin
+
+pricing: free

--- a/assets/apps/ferrosonic/index.yaml
+++ b/assets/apps/ferrosonic/index.yaml
@@ -7,7 +7,7 @@ description: "A terminal-based Subsonic music client written in Rust, featuring 
 screenshots:
   thumbnail: thumbnail.webp
 repoUrl: https://github.com/jaidaken/ferrosonic
-isFree: true
+pricing: free
 keywords:
   - terminal
   - rust

--- a/assets/apps/firmium/index.yaml
+++ b/assets/apps/firmium/index.yaml
@@ -26,7 +26,7 @@ screenshots:
     - search.webp
     - settings.webp
 
-isFree: true
+pricing: free
 
 keywords:
   - fast

--- a/assets/apps/flo/index.yaml
+++ b/assets/apps/flo/index.yaml
@@ -10,3 +10,5 @@ screenshots:
   gallery:
     - screen1.webp
 repoUrl: https://github.com/kepelet/flo
+
+pricing: free

--- a/assets/apps/foo_opensubsonic/index.yaml
+++ b/assets/apps/foo_opensubsonic/index.yaml
@@ -10,7 +10,7 @@ api: OpenSubsonic
 description: "A foobar2000 component for syncing libraries and playlists while streaming music directly from your Navidrome server."
 
 isOpenSource: true
-isFree: true
+pricing: free
 
 screenshots:
   thumbnail: thumbnail.webp

--- a/assets/apps/gelly/index.yaml
+++ b/assets/apps/gelly/index.yaml
@@ -10,7 +10,7 @@ screenshots:
     - screen1.webp
     - screen2.webp
 repoUrl: https://github.com/Fingel/gelly
-isFree: true
+pricing: free
 keywords:
   - rust
   - pipewire

--- a/assets/apps/isub/index.yaml
+++ b/assets/apps/isub/index.yaml
@@ -12,3 +12,5 @@ screenshots:
     - screen3.webp
     - screen4.webp
 repoUrl: https://github.com/einsteinx2/iSubMusicStreamer
+
+pricing: free

--- a/assets/apps/kolis-music/index.yaml
+++ b/assets/apps/kolis-music/index.yaml
@@ -11,3 +11,5 @@ screenshots:
   gallery:
     - screen1.webp
     - screen2.webp
+
+pricing: paid

--- a/assets/apps/lyris/index.yaml
+++ b/assets/apps/lyris/index.yaml
@@ -1,7 +1,7 @@
 name: Lyris
 url: https://getlyris.com
 isOpenSource: false
-isFree: true
+pricing: free
 
 platforms:
   ios:

--- a/assets/apps/melia/index.yaml
+++ b/assets/apps/melia/index.yaml
@@ -15,3 +15,5 @@ screenshots:
     - screen03.webp
     - screen04.webp
     - screen05.webp
+
+pricing: paid

--- a/assets/apps/meringo/index.yaml
+++ b/assets/apps/meringo/index.yaml
@@ -5,7 +5,7 @@ platforms:
     store: https://play.google.com/store/apps/details?id=app.meringo
 api: OpenSubsonic
 isOpenSource: false
-isFree: false
+pricing: trial
 description: Bit-perfect Android player for USB DACs with published, hash-verified receipts. Streams from Subsonic-family servers with direct play and no transcoding.
 keywords:
   - bit-perfect

--- a/assets/apps/mist/index.yaml
+++ b/assets/apps/mist/index.yaml
@@ -14,3 +14,5 @@ screenshots:
   gallery:
     - screen1.webp
     - screen2.webp
+
+pricing: free

--- a/assets/apps/musiver/index.yaml
+++ b/assets/apps/musiver/index.yaml
@@ -13,4 +13,4 @@ api: Navidrome
 description: "Cross-platform NAS music player supporting multiple servers with CarPlay, Android Auto, desktop lyrics, mini window mode, and global hotkeys. Features lyrics display, music roaming for discovery, desktop widgets, iOS shortcuts integration, and DLNA casting."
 screenshots:
   thumbnail: thumbnail.webp
-isFree: true
+pricing: free

--- a/assets/apps/musly/index.yaml
+++ b/assets/apps/musly/index.yaml
@@ -17,3 +17,5 @@ screenshots:
     - Screenshot_20260101_024751.webp
     - Screenshot_20260101_024803.webp
 repoUrl: https://github.com/dddevid/musly
+
+pricing: free

--- a/assets/apps/narjo/index.yaml
+++ b/assets/apps/narjo/index.yaml
@@ -12,4 +12,4 @@ screenshots:
     - screen3.webp
     - screen4.webp
     - screen5.webp
-isFree: false
+pricing: paid

--- a/assets/apps/nautiline/index.yaml
+++ b/assets/apps/nautiline/index.yaml
@@ -12,3 +12,5 @@ screenshots:
   gallery:
     - screen1.webp
     - screen2.webp
+
+pricing: paid

--- a/assets/apps/navi-player/index.yaml
+++ b/assets/apps/navi-player/index.yaml
@@ -14,3 +14,5 @@ keywords:
   - open-subsonic
   - material-3
   - media3
+
+pricing: free

--- a/assets/apps/navibeat-linux/index.yaml
+++ b/assets/apps/navibeat-linux/index.yaml
@@ -1,7 +1,7 @@
 name: NaviBeat for Linux
 url: https://navibeat.app/linux
 repoUrl: https://github.com/nenadjokic/navibeat-linux
-isFree: true
+pricing: free
 isOpenSource: false
 platforms:
   linux: true

--- a/assets/apps/navibeat/index.yaml
+++ b/assets/apps/navibeat/index.yaml
@@ -24,3 +24,5 @@ keywords:
   - rockbox
   - universal-purchase
   - offline
+
+pricing: paid

--- a/assets/apps/navic/index.yaml
+++ b/assets/apps/navic/index.yaml
@@ -12,3 +12,5 @@ screenshots:
     - now-playing.webp
     - lyrics.webp
 repoUrl: https://github.com/paigely/Navic
+
+pricing: free

--- a/assets/apps/netmusic/index.yaml
+++ b/assets/apps/netmusic/index.yaml
@@ -1,7 +1,7 @@
 name: NetMusic
 url: https://netmusicapp.com/
 isOpenSource: false
-isFree: true
+pricing: free
 
 platforms:
   ios:

--- a/assets/apps/nocturne/index.yaml
+++ b/assets/apps/nocturne/index.yaml
@@ -25,4 +25,5 @@ keywords:
   - visualizer
   - lyrics
   - mpris
-  
+
+pricing: free

--- a/assets/apps/nokkvi/index.yaml
+++ b/assets/apps/nokkvi/index.yaml
@@ -13,7 +13,7 @@ screenshots:
     - albums.webp
     - playlists-collage.webp
     - artists.webp
-isFree: true
+pricing: free
 keywords:
   - rust
   - pipewire

--- a/assets/apps/nostalgicpod/index.yaml
+++ b/assets/apps/nostalgicpod/index.yaml
@@ -17,3 +17,5 @@ screenshots:
     - screen4.webp
 keywords:
   - cover flow
+
+pricing: paid

--- a/assets/apps/playsub/index.yaml
+++ b/assets/apps/playsub/index.yaml
@@ -14,3 +14,5 @@ screenshots:
     - screen3.webp
     - screen4.webp
     - screen5.webp
+
+pricing: paid

--- a/assets/apps/plugin.kodi.navidrome/index.yaml
+++ b/assets/apps/plugin.kodi.navidrome/index.yaml
@@ -20,3 +20,5 @@ screenshots:
     - screen03.webp
     - screen04.webp
     - screen05.webp
+
+pricing: free

--- a/assets/apps/project-blue/index.yaml
+++ b/assets/apps/project-blue/index.yaml
@@ -12,3 +12,5 @@ screenshots:
     - screen3.webp
     - screen4.webp
 repoUrl: https://github.com/namehillsoftware/projectBlue
+
+pricing: free

--- a/assets/apps/psysonic/index.yaml
+++ b/assets/apps/psysonic/index.yaml
@@ -17,3 +17,5 @@ keywords:
   - rust
   - cross-platform
   - lastfm
+
+pricing: free

--- a/assets/apps/ratune/index.yaml
+++ b/assets/apps/ratune/index.yaml
@@ -14,7 +14,7 @@ screenshots:
     - screen3.webp
     - screen4.webp
     - screen5.webp
-isFree: true
+pricing: free
 keywords:
   - terminal
   - tui

--- a/assets/apps/raycast-extension/index.yaml
+++ b/assets/apps/raycast-extension/index.yaml
@@ -12,3 +12,5 @@ repoUrl: https://github.com/raycast/extensions/tree/9a82c450e1206396f9713e7cb371
 keywords:
   - macos
   - raycast
+
+pricing: free

--- a/assets/apps/record-collection/index.yaml
+++ b/assets/apps/record-collection/index.yaml
@@ -19,3 +19,5 @@ screenshots:
     - screenshot2.webp
     - screenshot3.webp
     - screenshot4.webp
+
+pricing: free

--- a/assets/apps/resonus/index.yaml
+++ b/assets/apps/resonus/index.yaml
@@ -25,7 +25,7 @@ screenshots:
 
 isOpenSource: true
 
-isFree: true
+pricing: free
 
 keywords:
   - jellyfin

--- a/assets/apps/saxon/index.yaml
+++ b/assets/apps/saxon/index.yaml
@@ -20,4 +20,4 @@ screenshots:
     - image3.webp
     - image4.webp
 
-isFree: true
+pricing: free

--- a/assets/apps/shelv/index.yaml
+++ b/assets/apps/shelv/index.yaml
@@ -16,3 +16,5 @@ screenshots:
     - mac.webp
     - tv.webp
 repoUrl: https://github.com/gatzenga/Shelv
+
+pricing: free

--- a/assets/apps/solound/index.yaml
+++ b/assets/apps/solound/index.yaml
@@ -15,7 +15,7 @@ screenshots:
     - screen1.webp
     - screen2.webp
 
-isFree: true
+pricing: free
 
 keywords:
   - android

--- a/assets/apps/sonawave/index.yaml
+++ b/assets/apps/sonawave/index.yaml
@@ -16,3 +16,5 @@ screenshots:
 keywords:
   - sonawave
   - harmonyos navidrome client
+
+pricing: freemium

--- a/assets/apps/sonora/index.yaml
+++ b/assets/apps/sonora/index.yaml
@@ -1,7 +1,7 @@
 name: Sonora
 url: https://sonora.gmadi.me
 isOpenSource: false
-isFree: true
+pricing: free
 platforms:
   ios:
     store: https://apps.apple.com/us/app/sonora-navidrome-client/id6760624152

--- a/assets/apps/sound-room/index.yaml
+++ b/assets/apps/sound-room/index.yaml
@@ -12,7 +12,7 @@ screenshots:
     - screen3.webp
     - screen4.webp
     - screen5.webp
-isFree: true
+pricing: free
 keywords:
   - navidrome jam
   - subsonic jam

--- a/assets/apps/strawberry/index.yaml
+++ b/assets/apps/strawberry/index.yaml
@@ -22,3 +22,5 @@ screenshots:
 keywords:
   - tag-editor
   - equalizer
+
+pricing: free

--- a/assets/apps/subfire/index.yaml
+++ b/assets/apps/subfire/index.yaml
@@ -9,3 +9,5 @@ description: "HTML5-based music player supporting web browsers, Chrome, Firefox,
 screenshots:
   thumbnail: thumbnail.webp
 repoUrl: https://github.com/acroyear/subfire
+
+pricing: free

--- a/assets/apps/submariner/index.yaml
+++ b/assets/apps/submariner/index.yaml
@@ -13,3 +13,5 @@ repoUrl: https://github.com/SubmarinerApp/Submariner
 keywords:
   - airplay
   - native
+
+pricing: free

--- a/assets/apps/submusic/index.yaml
+++ b/assets/apps/submusic/index.yaml
@@ -10,3 +10,5 @@ screenshots:
   gallery:
     - playlists.webp
 repoUrl: https://github.com/memen45/SubMusic
+
+pricing: free

--- a/assets/apps/subplayer/index.yaml
+++ b/assets/apps/subplayer/index.yaml
@@ -10,3 +10,5 @@ description: "A lightweight, React-based web music player designed as a function
 screenshots:
   thumbnail: thumbnail.webp
 repoUrl: https://github.com/peguerosdc/subplayer
+
+pricing: free

--- a/assets/apps/substreamer/index.yaml
+++ b/assets/apps/substreamer/index.yaml
@@ -1,7 +1,7 @@
 name: Substreamer
 url: https://substreamer.org/
 repoUrl: https://github.com/ghenry22/substreamer
-isFree: true
+pricing: free
 platforms:
   android:
     store: https://play.google.com/store/apps/details?id=com.ghenry22.substream2

--- a/assets/apps/subswift/index.yaml
+++ b/assets/apps/subswift/index.yaml
@@ -12,3 +12,5 @@ screenshots:
     - screen3.webp
 keywords:
   - tvOS
+
+pricing: paid

--- a/assets/apps/subtracks/index.yaml
+++ b/assets/apps/subtracks/index.yaml
@@ -10,3 +10,5 @@ screenshots:
     - screen1.webp
     - screen2.webp
 repoUrl: https://github.com/austinried/subtracks
+
+pricing: free

--- a/assets/apps/subtui/index.yaml
+++ b/assets/apps/subtui/index.yaml
@@ -11,7 +11,7 @@ screenshots:
     - screen1.webp
     - screen2.webp
 repoUrl: https://github.com/MattiaPun/SubTUI
-isFree: true
+pricing: free
 keywords:
   - terminal
   - minimal

--- a/assets/apps/subwave-radio/index.yaml
+++ b/assets/apps/subwave-radio/index.yaml
@@ -16,7 +16,7 @@ api: OpenSubsonic
 description: "A self-hosted personal radio station built on your Navidrome library: one shared Icecast broadcast where an AI DJ picks the tracks, voices the intros, station idents, time and weather, and takes plain-language song requests. Listen on the web, an installable PWA, or native iOS/Android players (beta)."
 
 isOpenSource: true
-isFree: true
+pricing: free
 
 screenshots:
   thumbnail: thumbnail.webp

--- a/assets/apps/subwave/index.yaml
+++ b/assets/apps/subwave/index.yaml
@@ -7,7 +7,7 @@ platforms:
 
 api: Subsonic
 
-isFree: false
+pricing: paid
 
 description: An Android music player featuring stunning Milkdrop visualizations powered by ProjectM, external equalizer support, synced lyrics, offline caching, local file playback, dashboard listening activity overview, and more!
 

--- a/assets/apps/supersonic/index.yaml
+++ b/assets/apps/supersonic/index.yaml
@@ -20,3 +20,5 @@ keywords:
   - lyrics
   - radio
 repoUrl: https://github.com/dweymouth/supersonic
+
+pricing: free

--- a/assets/apps/symfonium/index.yaml
+++ b/assets/apps/symfonium/index.yaml
@@ -15,3 +15,5 @@ keywords:
   - offline
   - chromecast
   - dlna
+
+pricing: trial

--- a/assets/apps/tempo/index.yaml
+++ b/assets/apps/tempo/index.yaml
@@ -10,3 +10,5 @@ screenshots:
     - screen1.webp
     - screen2.webp
 repoUrl: https://github.com/CappielloAntonio/tempo
+
+pricing: free

--- a/assets/apps/tempus/index.yaml
+++ b/assets/apps/tempus/index.yaml
@@ -10,3 +10,5 @@ screenshots:
   gallery:
     - screen2.webp
 repoUrl: https://github.com/eddyizm/tempus
+
+pricing: free

--- a/assets/apps/termsonic/index.yaml
+++ b/assets/apps/termsonic/index.yaml
@@ -8,3 +8,5 @@ description: "A terminal-based user interface (TUI) client for Subsonic-compatib
 screenshots:
   thumbnail: thumbnail.webp
 repoUrl: https://git.sixfoisneuf.fr/termsonic
+
+pricing: free

--- a/assets/apps/thunderdrome/index.yaml
+++ b/assets/apps/thunderdrome/index.yaml
@@ -12,3 +12,5 @@ screenshots:
     - screen1.webp
     - screen2.webp
 repoUrl: https://github.com/bricej13/thunderdrome
+
+pricing: free

--- a/assets/apps/tinysub/index.yaml
+++ b/assets/apps/tinysub/index.yaml
@@ -8,7 +8,7 @@ api: OpenSubsonic
 description: "A simple but full-featured web player for Open Subsonic compatible music servers, inspired by Strawberry with a unique queue-focused design"
 screenshots:
   thumbnail: thumbnail.webp
-isFree: true
+pricing: free
 keywords:
   - simple
   - lightweight

--- a/assets/apps/tributary/index.yaml
+++ b/assets/apps/tributary/index.yaml
@@ -9,7 +9,7 @@ api: OpenSubsonic
 description: "Tributary is a high-performance, Rhythmbox-style media manager written in pure Rust with GTK4 and libadwaita."
 screenshots:
   thumbnail: thumbnail.webp
-isFree: true
+pricing: free
 isOpenSource: true
 keywords:
   - gtk4

--- a/assets/apps/tritone/index.yaml
+++ b/assets/apps/tritone/index.yaml
@@ -2,7 +2,7 @@ name: Tritone
 url: https://tritone.dev
 repoUrl: https://github.com/Kyle8973/Tritone
 isOpenSource: true
-isFree: true
+pricing: free
 platforms:
   windows: true
   linux: true

--- a/assets/apps/tuneband/index.yaml
+++ b/assets/apps/tuneband/index.yaml
@@ -16,7 +16,7 @@ screenshots:
     - screen2.webp
     - screen3.webp
 
-isFree: true
+pricing: free
 
 keywords:
   - apple watch

--- a/assets/apps/ultrasonic/index.yaml
+++ b/assets/apps/ultrasonic/index.yaml
@@ -11,3 +11,5 @@ screenshots:
     - screen1.webp
     - screen2.webp
 repoUrl: https://gitlab.com/ultrasonic/ultrasonic
+
+pricing: free

--- a/assets/apps/upmpdcli/index.yaml
+++ b/assets/apps/upmpdcli/index.yaml
@@ -19,3 +19,5 @@ keywords:
   - upnp
   - dlna
   - chromecast
+
+pricing: free

--- a/assets/apps/vibrdrome/index.yaml
+++ b/assets/apps/vibrdrome/index.yaml
@@ -27,7 +27,7 @@ screenshots:
     - android-player.webp
     - web-library.webp
 
-isFree: true
+pricing: free
 
 keywords:
   - carplay

--- a/assets/apps/wavelength/index.yaml
+++ b/assets/apps/wavelength/index.yaml
@@ -9,7 +9,7 @@ screenshots:
   thumbnail: thumbnail.webp
   gallery:
     - screen1.webp
-isFree: false
+pricing: paid
 keywords:
   - mac
   - macos

--- a/assets/apps/wavio/index.yaml
+++ b/assets/apps/wavio/index.yaml
@@ -22,4 +22,4 @@ screenshots:
 
 isOpenSource: true
 
-isFree: true
+pricing: free

--- a/assets/apps/yuzic/index.yaml
+++ b/assets/apps/yuzic/index.yaml
@@ -22,7 +22,7 @@ screenshots:
     - screen3.webp
     - screen4.webp
 
-isFree: true
+pricing: free
 
 keywords:
   - jellyfin

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -367,33 +367,38 @@
     }
   }
 
-  .app-paid-badge {
+  .app-pricing-badge {
     margin-left: 0.5rem;
     cursor: help;
     vertical-align: middle;
 
-    .app-paid-pill {
+    .app-pricing-pill {
       display: inline-flex;
       align-items: center;
       gap: 0.3rem;
       height: 1.25rem;
       padding: 0 0.4rem;
-      background-color: #dc3545;
       color: #fff;
       border-radius: 3px;
       font-size: 0.7rem;
       font-weight: 600;
       vertical-align: middle;
       transform: translateY(-3px);
+      white-space: nowrap;
 
       i.fas {
         font-size: 0.75rem;
       }
     }
 
-    [data-bs-theme="dark"] & .app-paid-pill {
-      background-color: #b02a37;
-      color: #fff;
+    .app-pricing-pill--paid { background-color: #dc3545; }
+    .app-pricing-pill--freemium { background-color: #6c757d; }
+    .app-pricing-pill--trial { background-color: #0d6efd; }
+
+    [data-bs-theme="dark"] & {
+      .app-pricing-pill--paid { background-color: #b02a37; }
+      .app-pricing-pill--freemium { background-color: #565e64; }
+      .app-pricing-pill--trial { background-color: #0a58ca; }
     }
   }
 }

--- a/content/en/docs/developers/adding-apps.md
+++ b/content/en/docs/developers/adding-apps.md
@@ -60,17 +60,30 @@ Use the template at [`assets/apps/_template/index.yaml`](https://github.com/navi
 | `api`                   | Supported API: `OpenSubsonic`, `Subsonic`, or `Navidrome` |
 | `description`           | Brief description (1-2 sentences)                         |
 | `screenshots.thumbnail` | Filename of thumbnail image (must NOT be a logo)          |
+| `pricing`               | Pricing model: `free`, `freemium`, `trial`, or `paid` (see below) |
 
 ### Optional Fields
 
-| Field                 | Description                                                 |
-|-----------------------|-------------------------------------------------------------|
-| `repoUrl`             | Repository URL (GitHub, GitLab) - used for release date tracking |
-| `isOpenSource`        | Whether the source code is publicly available (see below)   |
-| `isFree`              | Whether the app is free (no purchase required) - boolean    |
-| `keywords`            | Additional search terms (max 6) - not displayed on app card |
-| `screenshots.gallery` | Array of additional screenshot filenames                    |
-| `platforms.*.store`   | Platform-specific store URLs                                |
+| Field                 | Description                                                       |
+|-----------------------|-------------------------------------------------------------------|
+| `repoUrl`             | Repository URL (GitHub, GitLab) - used for release date tracking  |
+| `isOpenSource`        | Whether the source code is publicly available (see below)         |
+| `keywords`            | Additional search terms (max 6) - not displayed on app card       |
+| `screenshots.gallery` | Array of additional screenshot filenames                          |
+| `platforms.*.store`   | Platform-specific store URLs                                      |
+
+### Pricing
+
+The `pricing` field controls the badge shown on the app card and the "Free Only" filter:
+
+| Value      | Meaning                                        | Badge shown        |
+|------------|------------------------------------------------|--------------------|
+| `free`     | No cost at all                                 | none               |
+| `freemium` | Free to download, has in-app purchases         | `In-App Purchases` |
+| `trial`    | Purchase required, but a free trial is offered | `Free Trial`       |
+| `paid`     | Purchase required                              | `Paid`             |
+
+The "Free Only" filter matches `free`, `freemium`, and `trial` apps, since all three cost nothing to start using. Only `paid` apps are hidden.
 
 ### Open Source vs Repository URL
 

--- a/layouts/apps/list.html
+++ b/layouts/apps/list.html
@@ -117,7 +117,7 @@
           <span><i class="fab fa-github"></i> Open Source Only</span>
         </label>
 
-        <label class="filter-checkbox filter-free">
+        <label class="filter-checkbox filter-free" title="Free to start using - includes apps with in-app purchases or a free trial">
           <input type="checkbox" id="filter-free" name="free">
           <span><i class="fas fa-tag"></i> Free Only</span>
         </label>

--- a/layouts/partials/app-card.html
+++ b/layouts/partials/app-card.html
@@ -7,9 +7,10 @@
 {{ $api := .api }}
 {{ $screenshots := .screenshots }}
 {{ $repoUrl := .repoUrl }}
-{{ $isFree := .isFree }}
 {{/* isOpenSource: if not set and repoUrl exists, default to true */}}
 {{ $isOpenSource := and $repoUrl (ne .isOpenSource false) }}
+{{/* pricing: free | freemium | trial | paid (required by app-schema.json) */}}
+{{ $pricing := .pricing }}
 
 {{/* Build full path to thumbnail */}}
 {{ $thumbnailPath := printf "apps/%s/%s" $appId $screenshots.thumbnail }}
@@ -37,9 +38,8 @@
 {{ $apiLower := lower $api }}
 
 {{ $ossAttr := cond $isOpenSource "true" "false" }}
-{{/* Open source apps are automatically considered free */}}
-{{ $isActuallyFree := or $isFree $isOpenSource }}
-{{ $freeAttr := cond $isActuallyFree "true" "false" }}
+{{/* "Free Only" also matches freemium and trial apps: they cost nothing to start using */}}
+{{ $freeAttr := cond (in (slice "free" "freemium" "trial") $pricing) "true" "false" }}
 
 {{ $keywords := default (slice) .keywords }}
 {{ $searchable := printf "%s %s %s" $name $description (delimit $keywords " ") | lower }}
@@ -108,9 +108,15 @@
             {{ end }}
           </a>
         {{ end }}
-        {{ if not $isActuallyFree }}
-          <span class="app-paid-badge" title="Paid">
-            <span class="app-paid-pill"><i class="fas fa-dollar-sign"></i>Paid</span>
+        {{/* "free" has no entry, so free apps render no badge */}}
+        {{ $pricingBadges := dict
+          "freemium" (dict "icon" "fa-cart-shopping" "label" "In-App Purchases" "title" "Free to use, with optional in-app purchases")
+          "trial" (dict "icon" "fa-hourglass-half" "label" "Free Trial" "title" "Purchase required, but a free trial is available")
+          "paid" (dict "icon" "fa-dollar-sign" "label" "Paid" "title" "Purchase required")
+        }}
+        {{ with index $pricingBadges $pricing }}
+          <span class="app-pricing-badge" title="{{ .title }}">
+            <span class="app-pricing-pill app-pricing-pill--{{ $pricing }}"><i class="fas {{ .icon }}"></i>{{ .label }}</span>
           </span>
         {{ end }}
       </h3>

--- a/layouts/partials/app-card.html
+++ b/layouts/partials/app-card.html
@@ -11,6 +11,7 @@
 {{ $isOpenSource := and $repoUrl (ne .isOpenSource false) }}
 {{/* pricing: free | freemium | trial | paid (required by app-schema.json) */}}
 {{ $pricing := .pricing }}
+{{ if not $pricing }}{{ errorf "app %q is missing the required 'pricing' field (free|freemium|trial|paid)" $appId }}{{ end }}
 
 {{/* Build full path to thumbnail */}}
 {{ $thumbnailPath := printf "apps/%s/%s" $appId $screenshots.thumbnail }}

--- a/openspec/specs/client-apps/spec.md
+++ b/openspec/specs/client-apps/spec.md
@@ -78,7 +78,12 @@ App developers SHALL be able to contribute their apps via YAML files.
 
 #### Scenario: Optional app fields
 - **WHEN** an app YAML file is created
-- **THEN** it MAY include: `repoUrl`, `isOpenSource`, `isFree`, `screenshots.gallery`, `keywords`, platform store URLs
+- **THEN** it MAY include: `repoUrl`, `isOpenSource`, `screenshots.gallery`, `keywords`, platform store URLs
+
+#### Scenario: App pricing model
+- **WHEN** an app YAML file is created
+- **THEN** it MUST include `pricing` set to one of `free`, `freemium`, `trial`, or `paid`
+- **AND** the card displays an `In-App Purchases`, `Free Trial`, or `Paid` badge for every value except `free`
 
 #### Scenario: Closed-source app with repository
 - **WHEN** an app has a GitHub/GitLab repository for releases or issue tracking


### PR DESCRIPTION
## What

Replaces the `isFree` boolean in the client app catalog with a required `pricing` enum, and adds two new card badges.

| Value | Meaning | Badge |
|---|---|---|
| `free` | No cost at all | none |
| `freemium` | Free to download, has in-app purchases | `In-App Purchases` |
| `trial` | Purchase required, free trial available | `Free Trial` |
| `paid` | Purchase required | `Paid` |

## Why

`isFree` could only say yes or no. It could not describe a free app with in-app purchases, or a paid app you can try before buying. Both are common in this catalog, so several entries were labelled in a way that misleads.

## Migration

All 84 entries were migrated. Every card renders as before except for five apps, whose store pages document a state `isFree` could not express:

| App | Store says | `pricing` |
|---|---|---|
| EchoSpace | Free, plus in-app purchases ($0.99/mo, $9.99/yr, $14.99 lifetime) | `freemium` |
| SonaWave | Free, plus a VIP tier via Huawei in-app purchase | `freemium` |
| Symfonium | Free install, 7-day trial, then a one-time $5 | `trial` |
| Meringo | Free install; its site states a 7-day trial, then a one-time $9.99 | `trial` |
| Cadence | $4.99 on the App Store, no in-app purchases | `paid` |

Six apps that previously carried no explicit value were each confirmed as straight purchases and are now explicitly `paid`: NaviBeat ($5.99), play:Sub ($4.99), SubSwift ($4.99), melia ($2.99), NostalgicPod ($5.29), and Kolis-Music.

## ⚠️ One card changes meaning: Cadence

`Cadence` carried `isFree: true`, but the App Store charges **$4.99** for both listed builds, with no in-app purchases:

| Listing | ID | Price |
|---|---|---|
| iOS | `6748620960` | $4.99 |
| macOS | `6748622506` | $4.99 |

Both are published by the same seller (Cory Dransfeldt), matching the `url` in the entry. Set to `pricing: paid`, so the card now shows a **Paid** badge where it previously showed none, and it no longer appears under the "Free Only" filter.

This is the one change here that contradicts what a contributor asserted rather than just re-encoding it. Happy to revert it to `free` if the entry is right and the store listing is misleading.

## Filter behaviour

"Free Only" matches `free`, `freemium`, and `trial` — all three cost nothing to start using. Only `paid` apps are hidden. The checkbox carries a tooltip saying so.

## Validation

`pricing` is in the schema's `required` array, so `validate-app-entry.js` — which runs on every PR touching `assets/apps/` — rejects both a missing field and an unknown value:

```
Schema validation: root must have required property 'pricing'
Schema validation: /pricing must be equal to one of the allowed values
  {"allowedValues":["free","freemium","trial","paid"]}
```

A missing `pricing` also fails the Hugo build with a message naming the app, rather than a bare template error:

```
ERROR app "tempo" is missing the required 'pricing' field (free|freemium|trial|paid)
```

## Verified

- All 84 apps pass `npm run validate:app`
- Site builds clean with CI's flags (`hugo --minify`), 101 pages
- Rendered page checked in a browser: 2 freemium, 2 trial, 11 paid badges; 73 of 84 pass "Free Only"; no layout break in light or dark theme

## Note, not fixed here

**Kolis-Music**'s App Store link returns 404 in every region I checked (US, CN, HK, MO), and the app is not in App Store search. Its own site still links the dead ID. Left as `paid` since there is no pricing evidence. Worth a separate look.
