### PR TITLE
docs(cli): document the missing list and fix commands

### DIFF
--- a/content/en/docs/usage/admin/cli.md
+++ b/content/en/docs/usage/admin/cli.md
@@ -199,6 +199,9 @@ just added it. The remap cannot be undone, so make a backup with `navidrome back
 you fix many files.
 {{% /alert %}}
 
+See [Missing Files](/docs/usage/library/missing-files/) for why files go missing, how to review them
+in the web UI, and how to purge them for good.
+
 ---
 
 ### `backup` (alias: `bkp`)

--- a/content/en/docs/usage/admin/cli.md
+++ b/content/en/docs/usage/admin/cli.md
@@ -92,7 +92,7 @@ navidrome -c /etc/navidrome/navidrome.toml --nobanner
 
 ## Command overview
 
-The built-in top-level administrative commands are: `inspect`, `scan`, `backup`, `pls`, `service`, `user`, and `plugin`.
+The built-in top-level administrative commands are: `inspect`, `scan`, `missing`, `backup`, `pls`, `service`, `user`, and `plugin`.
 
 ### `inspect`
 
@@ -144,6 +144,60 @@ navidrome scan -t 1:Music/Rock -t 2:Audiobooks
 # Read scan targets from file
 navidrome scan --target-file ./scan-targets.txt
 ```
+
+---
+
+### `missing`
+
+List files marked as missing, and remap a missing file onto an existing one.
+
+A file is marked missing when the scanner no longer finds it on disk. When you rename or move a
+file, the scanner normally reconnects it and carries over play counts, ratings, starred status and
+bookmarks. If the scanner cannot match the two files, the old entry stays missing and the new file
+starts with no history. `missing fix` does that remap by hand.
+
+```bash
+navidrome missing --help
+```
+
+Subcommands:
+
+- `list`: List all files currently marked as missing
+- `fix <missing> <target>`: Remap a missing file onto an existing file
+
+`missing list` flags:
+
+- `-f, --format`: Output format (`csv` or `json`, default: `csv`)
+
+`missing fix` takes two arguments. The first is the missing file, the second is the file to move
+the data onto. Each argument can be a media file ID, a library-relative path, or a
+`libraryID:path` pair. Use an ID or a `libraryID:path` pair when the same path exists in more than
+one library.
+
+Examples:
+
+```bash
+# List missing files as CSV (id, library id, title, album, artist, path)
+navidrome missing list
+
+# List missing files as JSON
+navidrome missing list --format json
+
+# Remap by library-relative path
+navidrome missing fix "Rock/Old Album/track01.mp3" "Rock/New Album/track01.mp3"
+
+# Remap by media file ID
+navidrome missing fix 3Unsdwsei9i2ZvRtFKRfwA 7KpqZmXe4Ab2NvTuGHRcxQ
+
+# Disambiguate with a libraryID:path pair
+navidrome missing fix 2:"Podcasts/ep01.mp3" 2:"Podcasts/episode-01.mp3"
+```
+
+{{% alert color="warning" title="Important" %}}
+The target file must already be in the library and must not be missing. Run a scan first if you
+just added it. The remap cannot be undone, so make a backup with `navidrome backup create` before
+you fix many files.
+{{% /alert %}}
 
 ---
 

--- a/content/en/docs/usage/library/missing-files/index.md
+++ b/content/en/docs/usage/library/missing-files/index.md
@@ -49,6 +49,28 @@ connected:
 
 In these cases, Navidrome will mark the files as missing until the drive is available again.
 
+## Reconnecting a Missing File to its Replacement
+
+If the scanner could not match an old file with its new path, you can remap the two by hand from
+the command line. This moves the play count, rating, starred status and bookmarks from the missing
+file onto the replacement, the same way the scanner does it automatically.
+
+First list the missing files to get their paths:
+
+```bash
+navidrome missing list
+```
+
+Then remap a missing file onto the file that replaced it:
+
+```bash
+navidrome missing fix "Rock/Old Album/track01.mp3" "Rock/New Album/track01.mp3"
+```
+
+The replacement must already be scanned into the library. See
+[`missing` in the CLI reference](/docs/usage/admin/cli/#missing) for the other argument forms and
+the JSON output option.
+
 ## Automatically Purging Missing Files
 
 Navidrome lets you control when missing files are automatically removed from the database using the `Scanner.PurgeMissing` option. This option accepts three possible values:


### PR DESCRIPTION
Documents the new `missing` CLI command from navidrome/navidrome#5928.

### CLI reference (`content/en/docs/usage/admin/cli.md`)

Adds a `missing` section after `scan`, and adds `missing` to the command overview list.

- `missing list`, including the `-f, --format` flag (`csv` or `json`) and the CSV column order taken from the current source (`id, library id, title, album, artist, path`).
- `missing fix <missing> <target>`, including the three argument forms it accepts: a media file ID, a library-relative path, or a `libraryID:path` pair.
- A warning that the target must already be scanned and not itself missing, and that the remap cannot be undone.
- A link to the Missing Files page.

### Missing Files (`content/en/docs/usage/library/missing-files/index.md`)

That page explained why files go missing and how to purge them, but had no way to reconnect one to its replacement. Adds a "Reconnecting a Missing File to its Replacement" section with the two commands and a link to the CLI reference.

The two pages now link to each other.

**This depends on navidrome/navidrome#5928, which is still open.** Please hold this until that PR merges, since the flags and CSV columns could still change.

Not verified in a local browser. The change is plain markdown using shortcodes already present on both pages, so the risk is low, but the anchor link to `/docs/usage/admin/cli/#missing` is worth a click on the preview build.